### PR TITLE
Show message when a list of build tasks cannot be gathered for a workspace folder

### DIFF
--- a/extension/src/client/provider/task/TaskProvider.ts
+++ b/extension/src/client/provider/task/TaskProvider.ts
@@ -27,6 +27,7 @@ interface VrealizeTaskDefinition extends vscode.TaskDefinition {
 
 export class TaskProvider implements vscode.TaskProvider, Registrable {
     private readonly logger = Logger.get("TaskProvider")
+    private context: vscode.ExtensionContext
 
     dispose() {
         // empty
@@ -56,9 +57,10 @@ export class TaskProvider implements vscode.TaskProvider, Registrable {
     register(context: vscode.ExtensionContext,
              clientWindow: ClientWindow): void {
         this.logger.debug("Registering the task provider")
+        this.context = context
 
         const providerRegistration = vscode.tasks.registerTaskProvider(extensionShortName, this)
-        context.subscriptions.push(this, providerRegistration)
+        this.context.subscriptions.push(this, providerRegistration)
     }
 
     private tasksForWorkspace(folder: vscode.WorkspaceFolder, excludePatterns: string[]) {
@@ -83,7 +85,7 @@ export class TaskProvider implements vscode.TaskProvider, Registrable {
         } catch (e) {
             const msg = `Couldn't generate task list for workspace folder '${folder.uri.fsPath}'. Cause: ${e.message}`
             this.logger.warn(msg)
-            vscode.window.showErrorMessage(msg)
+            this.showWarning(msg, folder.uri.fsPath)
         }
 
         return tasks.map(taskDef => this.newShellTask(taskDef, folder))
@@ -138,5 +140,21 @@ export class TaskProvider implements vscode.TaskProvider, Registrable {
         task.group = vscode.TaskGroup.Build
 
         return task
+    }
+
+    private showWarning(message: string, workspaceFolderPath: string): void {
+        const state = this.context.globalState.get("ignoredTaskWarnings", {})
+
+        if (state[workspaceFolderPath] !== true) {
+            vscode.window.showWarningMessage(message, "Ignore for Project").then(
+                selected => {
+                    if (selected === "Ignore for Project") {
+                        // TODO: Wrap this into a more pleasant API that will be used across the extenion
+                        state[workspaceFolderPath] = true
+                        this.context.globalState.update("ignoredTaskWarnings", state)
+                    }
+                }
+            )
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The list of build tasks is compiled based on the root pom.xml of the opened project folders. If there is a problem with preparing the task list, an error notification will be shown with a reason (instead of silent failure with empty list).

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have tested against live vRO/vRA, if applicable
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Screenshot

<img width="469" alt="Screen Shot 2019-04-19 at 10 22 14" src="https://user-images.githubusercontent.com/215676/56412605-771fe300-628d-11e9-9fcf-206825abd203.png">
