### PR TITLE
Fix ENOENT errors when creating new project

### DIFF
--- a/common/src/types/project.ts
+++ b/common/src/types/project.ts
@@ -15,5 +15,5 @@ export interface ProjectPickInfo {
     groupId: string
     name: string
     workflowsPath?: string
-    destination?: string
+    destination?: vscode.Uri
 }

--- a/common/src/uri.ts
+++ b/common/src/uri.ts
@@ -3,11 +3,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-import * as URL from "url"
-
 import { URI } from "vscode-uri"
 
-const fileSchemeLength = "file://".length - 1
 export const O11N_URI_SCHEME = "o11n"
 
 export interface O11nContentLocation {
@@ -37,12 +34,4 @@ export function uriToLocation(uri: URI): O11nContentLocation {
         id: fragment,
         extension
     }
-}
-
-export function pathToUrl(path: string): string {
-    return URL.format(URL.parse(`file://${path}`))
-}
-
-export function urlToPath(uri: string): string {
-    return uri.substr(fileSchemeLength)
 }

--- a/extension/src/client/command/NewProject.ts
+++ b/extension/src/client/command/NewProject.ts
@@ -5,7 +5,7 @@
 
 import * as path from "path"
 
-import { AutoWire, Logger, MavenCliProxy, ProjectPickInfo, ProjectType, uri } from "vrealize-common"
+import { AutoWire, Logger, MavenCliProxy, ProjectPickInfo, ProjectType } from "vrealize-common"
 import * as vscode from "vscode"
 
 import { Commands, MavenPom } from "../constants"
@@ -150,7 +150,7 @@ export class NewProject extends Command {
         })
 
         if (uri && uri.length > 0) {
-            this.state.destination = uri[0].toString()
+            this.state.destination = uri[0];
             this.generateProject()
         }
     }
@@ -182,7 +182,7 @@ export class NewProject extends Command {
                                 this.state.projectType.id,
                                 this.state.groupId,
                                 this.state.name,
-                                uri.urlToPath(this.state.destination),
+                                this.state.destination.fsPath,
                                 this.state.projectType.containsWorkflows,
                                 this.state.workflowsPath
                             )
@@ -194,7 +194,7 @@ export class NewProject extends Command {
                     }
 
                     if (!canceled) {
-                        const projectFolder = path.join(this.state.destination, this.state.name)
+                        const projectFolder = path.join(this.state.destination.toString(), this.state.name)
                         vscode.commands.executeCommand(
                             "vscode.openFolder",
                             vscode.Uri.parse(projectFolder),


### PR DESCRIPTION
### Description
Fixed usage of Uri and fspath that relates to bug #34

<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have tested against live vRO/vRA, if applicable
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested with VSCode debug instance - created new project from the Command Palete.

### Release Notes
Fixed ENOENT error when creating new projects (both on Linux/macOS/Windows).