### PR TITLE
Updates to contributing guide and GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,14 +25,16 @@ labels: type:bug
 ### Environment
 
 #### Client
-- vRealize Developer Tools Version:
-- vRealize Build Tools Version:
-- VSCode Version:
-- OS Version:
+
+-   vRealize Developer Tools Version:
+-   vRealize Build Tools Version:
+-   VSCode Version:
+-   OS Version:
 
 #### Server
-- vRealize Automation Version:
-- vRealize Orchestrator Version:
+
+-   vRealize Automation Version:
+-   vRealize Orchestrator Version:
 
 ### Failure Logs
 
@@ -40,6 +42,10 @@ labels: type:bug
 Please enable output channel logging by setting `"vrdev.log": "debug"` in your settings.json. This will enable logging to the `vRealize Developer Tools` & `vRO - Language Server` channels in the Output pane.
 Once enabled, please attempt to reproduce the issue (if possible) and attach any relevant log lines from both channels.
 -->
+
+### Related issues and PRs
+
+<!-- Link any related issues and pull requests here using #number or user/repo#number -->
 
 ### Additional Context
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,3 +48,7 @@ Examples:
 ### Screenshot
 
 <!-- Include an image of the most relevant user-facing change, if any. -->
+
+### Related issues and PRs
+
+<!-- Link any related issues and pull requests here using #number or user/repo#number -->

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 365
+daysUntilStale: 60
 
 # Number of days of inactivity before a stale Issue or Pull Request is closed
 daysUntilClose: 14

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ git clone https://github.com/vmware/vrealize-developer-tools.git
 #### Prerequisites
 
 -   [Git](https://git-scm.com/)
--   [Node.js](https://nodejs.org/en/), `>= 9.0.0`
+-   [Node.js](https://nodejs.org/en/), `>= 10.0.0`
 -   [yarn](https://yarnpkg.com/en/), `>= 1.10.1`
 -   [gulp CLI](https://gulpjs.com/), `>= 2.0.1`
 -   [Visual Studio Code](https://code.visualstudio.com/), `>= 1.30.0`


### PR DESCRIPTION
- Update contributing guide with node 10+ requirement
- Reduce the stale issue timeout from 1y to 2mo
- Add section for related issues/PRs in the GitHub templates 