### PR TITLE
 Fixed #34 - Cannot open a freshly generated project on Windows

### DIFF
--- a/extension/src/client/command/NewProject.ts
+++ b/extension/src/client/command/NewProject.ts
@@ -194,10 +194,10 @@ export class NewProject extends Command {
                     }
 
                     if (!canceled) {
-                        const projectFolder = path.join(this.state.destination.toString(), this.state.name)
+                        const projectFolder = path.join(this.state.destination.fsPath, this.state.name)
                         vscode.commands.executeCommand(
                             "vscode.openFolder",
-                            vscode.Uri.parse(projectFolder),
+                            vscode.Uri.file(projectFolder),
                             vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0
                         )
                     }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fix the `Path does not exist` error when opening a generated project on Windows (reported [here](https://github.com/vmware/vrealize-developer-tools/issues/34#issuecomment-508415387))

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have tested against live vRO/vRA, if applicable
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested on a Windows machine that was reproducing the issue when opening a generated project

### Release Notes

- Generated projects using the `vRealize: New Project` are now correctly opened on Windows

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in vRealize Developer Tools' release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

Examples:

- New setting to *exclude* certain projects from the list of build tasks (`Cmd+Shift+B`) by using glob patterns.
- Support for Multi-root Workspaces that allows opening more than one vRO project into single vscode window.
- Dynamically create build tasks (`Cmd+Shift+B`) based on project's type and modules.

-->
