### PR TITLE
Fixed #47 - Failed to fetch vRO element using the Command Palette

### DIFF
--- a/extension/src/client/command/ShowActions.ts
+++ b/extension/src/client/command/ShowActions.ts
@@ -6,7 +6,7 @@
 import { AutoWire, Logger, VroElementPickInfo, VroRestClient } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { Commands } from "../constants"
+import { Commands, ElementKinds } from "../constants"
 import { Command } from "./Command"
 import { ContentLocation } from "../provider/content/ContentLocation"
 import { ConfigurationManager, EnvironmentManager } from "../manager"
@@ -84,8 +84,8 @@ export class ShowActions extends Command {
         }
 
         const url = ContentLocation.with({
-            scheme: "vro",
-            type: "action",
+            scheme: ContentLocation.VRO_URI_SCHEME,
+            type: ElementKinds.Action,
             name: selectedAction.name,
             extension: "js",
             id: selectedAction.id

--- a/extension/src/client/command/ShowConfigurations.ts
+++ b/extension/src/client/command/ShowConfigurations.ts
@@ -6,7 +6,7 @@
 import { AutoWire, Logger, VroElementPickInfo, VroRestClient } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { Commands } from "../constants"
+import { Commands, ElementKinds } from "../constants"
 import { Command } from "./Command"
 import { ContentLocation } from "../provider/content/ContentLocation"
 import { ConfigurationManager, EnvironmentManager } from "../manager"
@@ -50,8 +50,8 @@ export class ShowConfigurations extends Command {
         }
 
         const url = ContentLocation.with({
-            scheme: "vro",
-            type: "config",
+            scheme: ContentLocation.VRO_URI_SCHEME,
+            type: ElementKinds.Configuraion,
             name: selected.name,
             extension: "xml",
             id: selected.id

--- a/extension/src/client/command/ShowResources.ts
+++ b/extension/src/client/command/ShowResources.ts
@@ -6,7 +6,7 @@
 import { AutoWire, Logger, VroElementPickInfo, VroRestClient } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { Commands } from "../constants"
+import { Commands, ElementKinds } from "../constants"
 import { Command } from "./Command"
 import { ContentLocation } from "../provider/content/ContentLocation"
 import { ConfigurationManager, EnvironmentManager } from "../manager"
@@ -50,8 +50,8 @@ export class ShowResources extends Command {
 
         const [name, extension] = selected.name.split(".")
         const url = ContentLocation.with({
-            scheme: "vro",
-            type: "resource",
+            scheme: ContentLocation.VRO_URI_SCHEME,
+            type: ElementKinds.Resource,
             id: selected.id,
             name,
             extension

--- a/extension/src/client/command/ShowWorkflows.ts
+++ b/extension/src/client/command/ShowWorkflows.ts
@@ -6,7 +6,7 @@
 import { AutoWire, Logger, VroElementPickInfo, VroRestClient } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { Commands } from "../constants"
+import { Commands, ElementKinds } from "../constants"
 import { Command } from "./Command"
 import { ContentLocation } from "../provider/content/ContentLocation"
 import { ConfigurationManager, EnvironmentManager } from "../manager"
@@ -50,8 +50,8 @@ export class ShowWorkflows extends Command {
         }
 
         const url = ContentLocation.with({
-            scheme: "vro",
-            type: "workflow",
+            scheme: ContentLocation.VRO_URI_SCHEME,
+            type: ElementKinds.Workflow,
             name: selected.name,
             extension: "xml",
             id: selected.id

--- a/extension/src/client/provider/content/ContentLocation.ts
+++ b/extension/src/client/provider/content/ContentLocation.ts
@@ -34,8 +34,8 @@ export class ContentLocation {
     }): ContentLocation {
         return new ContentLocation(
             components.scheme,
-            components.type,
-            components.name,
+            components.type.replace("vrdev:element:kind:", ""),
+            components.name.substring(components.name.lastIndexOf("/") + 1),
             components.id,
             components.extension
         )


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The internal content URI had the package name included which was causing the error. The package name is not needed, so I removed it.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have tested against live vRO/vRA, if applicable
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested towards vRO 7.4

### Related issues and PRs
#47
