### PR TITLE
Fixed #49 - Throw an error during extension load when settings.xml does not exist

### DIFF
--- a/extension/src/client/manager/ConfigurationManager.ts
+++ b/extension/src/client/manager/ConfigurationManager.ts
@@ -95,6 +95,14 @@ export class ConfigurationManager extends BaseConfiguration implements Registrab
     }
 
     private forceLoadProfiles(): MavenProfilesMap | undefined {
+        if (!fs.existsSync(this.settingsXmlPath)) {
+            vscode.window.showErrorMessage("Missing maven settings file: ~/.m2/settings.xml", "Reload Window").then(selected => {
+                if (selected === "Reload Window") {
+                    vscode.commands.executeCommand("workbench.action.reloadWindow")
+                }
+            })
+        }
+
         const settingsXmlContent = fs.readFileSync(this.settingsXmlPath)
 
         if (settingsXmlContent.length < 1) {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

During extension load, the ~/.m2/settings.xml is loaded. If the file doesn't exist, the extension silently doesn't load and the only error visible is in the dev tools' console.

This PR fixes this behavior by showing an error in the vscode UI and offers a reload button.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have tested against live vRO/vRA, if applicable
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Screenshot
<img width="466" alt="Screen Shot 2019-11-20 at 18 44 31" src="https://user-images.githubusercontent.com/215676/69258780-d64c2a00-0bc5-11ea-9a30-e725c49858d0.png">


### Related issues and PRs

#49