### PR TITLE
Hide irrelevant features of the extension when non-vRealize project is opened

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,14 +15,10 @@
   "files.associations": {
     "**/build/azure-pipelines/**/*.yml": "azure-pipelines"
   },
-  "eslint.autoFixOnSave": true,
-  "eslint.validate": [
-    "javascript",
-    {
-      "language": "typescript",
-      "autoFix": true
-    }
-  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.validate": ["javascript", "typescript"],
 
   "editor.formatOnSave": true,
   "[javascript]": {

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,5 +1,6 @@
-"@types:registry" "https://registry.npmjs.org"
-"@protobufjs:registry" "https://registry.npmjs.org"
+registry "https://registry.yarnpkg.com"
+"@types:registry" "https://registry.yarnpkg.com"
+"@protobufjs:registry" "https://registry.yarnpkg.com"
 --install.ignore-engines true
 --add.ignore-engines true
 --version.no-git-tag-version true

--- a/build/release.js
+++ b/build/release.js
@@ -6,7 +6,7 @@
 const gulp = require("gulp")
 const log = require("fancy-log")
 const publishRelease = require("gulp-github-release")
-const { ReleaseNotes } = require("pull-release-notes")
+const { ReleaseNotes } = require("@nblagoev/pull-release-notes")
 
 const REPO_OWNER = "vmware"
 const REPO_NAME = "vrealize-developer-tools"

--- a/common/src/platform/BaseEnvironment.ts
+++ b/common/src/platform/BaseEnvironment.ts
@@ -65,16 +65,12 @@ export abstract class BaseEnvironment {
         return path.join(tokensFolder, this.getHostname())
     }
 
-    getLocalHintsDir(workspaceFolder: WorkspaceFolder): string {
+    private getLocalHintsDir(workspaceFolder: WorkspaceFolder): string {
         return this.createAndResolveDir(workspaceFolder.uri.fsPath, ".o11n", "hints")
     }
 
     getGlobalO11nDir(): string {
         return this.createAndResolveDir(this.homeDir, ".o11n")
-    }
-
-    getLocalO11nDir(workspaceFolder: WorkspaceFolder): string {
-        return this.createAndResolveDir(workspaceFolder.uri.fsPath, ".o11n")
     }
 
     resolveHintFile(name: string, workspaceFolder?: WorkspaceFolder): string {
@@ -95,10 +91,6 @@ export abstract class BaseEnvironment {
         }
 
         return path.join(this.getGlobalHintsDir(), this.getHostname())
-    }
-
-    resolveOutputFile(name: string, workspaceFolder: WorkspaceFolder): string {
-        return path.join(this.getLocalHintsDir(workspaceFolder), "..", name)
     }
 
     resolvePluginHintFiles(): string[] {

--- a/extension/src/client/ModuleRegistry.ts
+++ b/extension/src/client/ModuleRegistry.ts
@@ -6,7 +6,6 @@
 import { di, Logger } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { ClientWindow } from "./ui"
 import { Registrable } from "./Registrable"
 
 type Constructable<T> = new () => T
@@ -15,7 +14,7 @@ export class ModuleRegistry {
     private readonly container: di.Container
     private readonly logger = Logger.get("ModuleRegistry")
 
-    constructor(private context: vscode.ExtensionContext, private clientWindow: ClientWindow) {
+    constructor(private context: vscode.ExtensionContext) {
         this.container = new di.Container()
     }
 
@@ -44,7 +43,7 @@ export class ModuleRegistry {
             }
 
             if (this.isRegistrable(clsInstance)) {
-                clsInstance.register(this.context, this.clientWindow)
+                clsInstance.register(this.context)
             }
         }
     }

--- a/extension/src/client/Registrable.ts
+++ b/extension/src/client/Registrable.ts
@@ -5,8 +5,6 @@
 
 import * as vscode from "vscode"
 
-import { ClientWindow } from "./ui"
-
 export interface Registrable {
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void
+    register(context: vscode.ExtensionContext): void
 }

--- a/extension/src/client/command/Command.ts
+++ b/extension/src/client/command/Command.ts
@@ -6,11 +6,10 @@
 import { Logger } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { ClientWindow } from "../ui"
 import { Registrable } from "../Registrable"
 
 export abstract class Command implements Registrable {
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void {
+    register(context: vscode.ExtensionContext): void {
         Logger.get("Command").debug(`Registering command '${this.commandId}'`)
 
         const disposable: vscode.Disposable = vscode.commands.registerCommand(this.commandId, (...args: any[]) =>

--- a/extension/src/client/command/EditorCommand.ts
+++ b/extension/src/client/command/EditorCommand.ts
@@ -6,11 +6,10 @@
 import { Logger } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { ClientWindow } from "../ui"
 import { Registrable } from "../Registrable"
 
 export abstract class EditorCommand implements Registrable {
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void {
+    register(context: vscode.ExtensionContext): void {
         Logger.get("EditorCommand").debug(`Registering editor command '${this.commandId}'`)
 
         const disposable: vscode.Disposable = vscode.commands.registerTextEditorCommand(

--- a/extension/src/client/command/NewProject.ts
+++ b/extension/src/client/command/NewProject.ts
@@ -10,7 +10,7 @@ import * as vscode from "vscode"
 
 import { Commands, Patterns } from "../constants"
 import { ConfigurationManager, EnvironmentManager } from "../manager"
-import { MultiStepInput, QuickPickParameters } from "../ui"
+import { MultiStepInput, QuickPickParameters } from "../ui/MultiStepInput"
 import { Command } from "./Command"
 
 interface State extends ProjectPickInfo {

--- a/extension/src/client/command/RunAction.ts
+++ b/extension/src/client/command/RunAction.ts
@@ -14,7 +14,6 @@ import * as vscode from "vscode"
 
 import { Commands, OutputChannels } from "../constants"
 import { ConfigurationManager, EnvironmentManager } from "../manager"
-import { ClientWindow } from "../ui"
 import { Command } from "./Command"
 
 const IIFE_WRAPPER_PATTERN = /\(function\s*\(\)\s*{([\s\S]*)}\);?/
@@ -43,8 +42,8 @@ export class RunAction extends Command {
         this.vrotsc = new VrotscCliProxy(this.logger)
     }
 
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void {
-        super.register(context, clientWindow)
+    register(context: vscode.ExtensionContext): void {
+        super.register(context)
 
         this.runtimeExceptionDecoration = vscode.window.createTextEditorDecorationType({
             isWholeLine: true,

--- a/extension/src/client/constants.ts
+++ b/extension/src/client/constants.ts
@@ -8,6 +8,7 @@ export const extensionShortName = "vRealize"
 export enum BuiltInCommands {
     Open = "vscode.open",
     OpenFolder = "vscode.openFolder",
+    ReloadWindow = "workbench.action.reloadWindow",
     SetContext = "setContext"
 }
 
@@ -40,6 +41,11 @@ export enum Commands {
 
 export enum FixCommands {
     PomFixLine = "vrdev.pom.diagnostics.fixLine"
+}
+
+export enum CommandContext {
+    EmptyProperties = "vrdev:properties:empty",
+    Project = "vrdev:context:project"
 }
 
 export enum Diagnostics {

--- a/extension/src/client/manager/EnvironmentManager.ts
+++ b/extension/src/client/manager/EnvironmentManager.ts
@@ -6,7 +6,7 @@
 import { AutoWire, BaseEnvironment, Logger, WorkspaceFolder } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { extensionShortName } from "../constants"
+import { extensionShortName, ProjectArchetypes } from "../constants"
 import { ConfigurationManager } from "./ConfigurationManager"
 
 @AutoWire
@@ -25,5 +25,13 @@ export class EnvironmentManager extends BaseEnvironment {
 
     get displayName(): string {
         return extensionShortName
+    }
+
+    hasRelevantProject(): boolean {
+        const projectTypes = Object.values(ProjectArchetypes) as string[]
+
+        return this.workspaceFolders.some(folder => {
+            return !!folder.projectType && projectTypes.includes(folder.projectType)
+        })
     }
 }

--- a/extension/src/client/provider/codeAction/LintCodeActionProvider.ts
+++ b/extension/src/client/provider/codeAction/LintCodeActionProvider.ts
@@ -8,7 +8,6 @@ import * as vscode from "vscode"
 
 import { Linter } from "../../lint"
 import { EnvironmentManager } from "../../manager"
-import { ClientWindow } from "../../ui"
 import { Registrable } from "../../Registrable"
 
 export abstract class LintCodeActionProvider implements vscode.CodeActionProvider, Registrable {
@@ -19,7 +18,7 @@ export abstract class LintCodeActionProvider implements vscode.CodeActionProvide
     protected abstract get documentSelector(): vscode.DocumentSelector
     protected abstract get fixCommandId(): string
 
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void {
+    register(context: vscode.ExtensionContext): void {
         this.logger.debug(`Registering lint code action provider with document selector ${this.documentSelector}`)
 
         context.subscriptions.push(

--- a/extension/src/client/provider/content/ContentProvider.ts
+++ b/extension/src/client/provider/content/ContentProvider.ts
@@ -9,7 +9,6 @@ import { AutoWire, Logger, VroRestClient } from "vrealize-common"
 import * as vscode from "vscode"
 import * as fs from "fs-extra"
 
-import { ClientWindow } from "../../ui"
 import { Registrable } from "../../Registrable"
 import { ConfigurationManager, EnvironmentManager } from "../../manager"
 import { RemoteDocument } from "./RemoteDocument"
@@ -33,7 +32,7 @@ export class ContentProvider implements vscode.TextDocumentContentProvider, Regi
         this.documents.clear()
     }
 
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void {
+    register(context: vscode.ExtensionContext): void {
         this.logger.debug(`Registering content provider for URI scheme ${ContentLocation.VRO_URI_SCHEME}`)
         this.subscriptions = vscode.workspace.onDidCloseTextDocument(doc => this.documents.delete(doc.uri.toString()))
         const providerRegistration = vscode.workspace.registerTextDocumentContentProvider(

--- a/extension/src/client/provider/explorer/PropertiesProvider.ts
+++ b/extension/src/client/provider/explorer/PropertiesProvider.ts
@@ -6,7 +6,7 @@
 import { AutoWire, Logger } from "vrealize-common"
 import * as vscode from "vscode"
 
-import { BuiltInCommands, Commands, Views } from "../../constants"
+import { BuiltInCommands, CommandContext, Commands, Views } from "../../constants"
 import { Registrable } from "../../Registrable"
 import { AbstractNode } from "./model"
 import { PropertyNode } from "./model/leaf/PropertyNode"
@@ -28,7 +28,7 @@ export class PropertiesProvider implements vscode.TreeDataProvider<AbstractNode>
             showCollapseAll: true,
             treeDataProvider: this
         })
-        vscode.commands.executeCommand(BuiltInCommands.SetContext, "vrdev:properties:empty", true)
+        vscode.commands.executeCommand(BuiltInCommands.SetContext, CommandContext.EmptyProperties, true)
 
         const showProperties = vscode.commands.registerCommand(Commands.ShowItemProperties, (node: AbstractNode) =>
             this.refresh(node)

--- a/extension/src/client/provider/task/TaskProvider.ts
+++ b/extension/src/client/provider/task/TaskProvider.ts
@@ -13,7 +13,6 @@ import { Logger, PomFile, TasksInfo } from "vrealize-common"
 import * as vscode from "vscode"
 
 import { extensionShortName } from "../../constants"
-import { ClientWindow } from "../../ui"
 import { Registrable } from "../../Registrable"
 import { TASKS_BY_TOOLCHAIN_PARENT } from "./DefaultTasksJson"
 
@@ -54,7 +53,7 @@ export class TaskProvider implements vscode.TaskProvider, Registrable {
         return undefined
     }
 
-    register(context: vscode.ExtensionContext, clientWindow: ClientWindow): void {
+    register(context: vscode.ExtensionContext): void {
         this.logger.debug("Registering the task provider")
         this.context = context
 

--- a/extension/src/client/provider/task/TaskProvider.ts
+++ b/extension/src/client/provider/task/TaskProvider.ts
@@ -9,12 +9,13 @@ import * as fs from "fs-extra"
 import * as jsonParser from "jsonc-parser"
 import * as _ from "lodash"
 import * as micromatch from "micromatch"
-import { Logger, PomFile, TasksInfo } from "vrealize-common"
+import { AutoWire, Logger, PomFile, TasksInfo } from "vrealize-common"
 import * as vscode from "vscode"
 
 import { extensionShortName } from "../../constants"
 import { Registrable } from "../../Registrable"
 import { TASKS_BY_TOOLCHAIN_PARENT } from "./DefaultTasksJson"
+import { EnvironmentManager } from "../../manager"
 
 interface VrealizeTaskDefinition extends vscode.TaskDefinition {
     command: string
@@ -24,9 +25,14 @@ interface VrealizeTaskDefinition extends vscode.TaskDefinition {
     osx?: { command: string }
 }
 
+@AutoWire
 export class TaskProvider implements vscode.TaskProvider, Registrable {
     private readonly logger = Logger.get("TaskProvider")
     private context: vscode.ExtensionContext
+
+    constructor(private env: EnvironmentManager) {
+        // empty
+    }
 
     dispose() {
         // empty
@@ -35,7 +41,7 @@ export class TaskProvider implements vscode.TaskProvider, Registrable {
     async provideTasks(token?: vscode.CancellationToken): Promise<vscode.Task[]> {
         const tasksConf = vscode.workspace.getConfiguration("vrdev").get<TasksInfo>("tasks")
 
-        if (tasksConf && tasksConf.disable === true) {
+        if (tasksConf && tasksConf.disable === true || !this.env.hasRelevantProject()) {
             return []
         }
 

--- a/extension/src/client/ui/StatusBarController.ts
+++ b/extension/src/client/ui/StatusBarController.ts
@@ -3,35 +3,49 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { Logger } from "vrealize-common"
+import { AutoWire, Logger } from "vrealize-common"
 import * as vscode from "vscode"
 
 import { Commands } from "../constants"
-import { ConfigurationManager } from "../manager"
+import { ConfigurationManager, EnvironmentManager } from "../manager"
+import { Registrable } from "../Registrable"
 
-export class ClientWindow implements vscode.Disposable {
-    private readonly logger = Logger.get("ClientWindow")
+@AutoWire
+export class StatusBarController implements Registrable, vscode.Disposable {
+    private readonly logger = Logger.get("StatusBarController")
     private readonly collectionButton: vscode.StatusBarItem
     private readonly collectionStatus: vscode.StatusBarItem
+    private readonly config: ConfigurationManager
+    private readonly env: EnvironmentManager
 
     profileName: string | undefined
 
-    constructor(initialProfileName: string | undefined, context: vscode.ExtensionContext) {
-        this.logger.debug("Instantiating the client window")
-
-        context.subscriptions.push(
-            vscode.commands.registerCommand(Commands.EventCollectionStart, this.onCollectionStart.bind(this)),
-            vscode.commands.registerCommand(Commands.EventCollectionSuccess, this.onCollectionSuccess.bind(this)),
-            vscode.commands.registerCommand(Commands.EventCollectionError, this.onCollectionError.bind(this))
-        )
+    constructor(config: ConfigurationManager, env: EnvironmentManager) {
+        this.logger.debug("Instantiating the status bar controller")
 
         this.collectionStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10101)
         this.collectionButton = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 10100)
+        this.profileName = config.vrdev.maven.profile
+        this.config = config
+        this.env = env
+    }
+
+    register(context: vscode.ExtensionContext): void {
+        context.subscriptions.push(this)
+
+        if (this.env.hasRelevantProject()) {
+            context.subscriptions.push(
+                vscode.commands.registerCommand(Commands.EventCollectionStart, this.onCollectionStart.bind(this)),
+                vscode.commands.registerCommand(Commands.EventCollectionSuccess, this.onCollectionSuccess.bind(this)),
+                vscode.commands.registerCommand(Commands.EventCollectionError, this.onCollectionError.bind(this))
+            )
+        }
 
         this.collectionStatus.text = "$(plug) $(kebab-horizontal)"
-        this.profileName = initialProfileName
-
         this.collectionStatus.show()
+
+        this.config.onDidChangeConfig(this.onConfigurationOrProfilesChanged, this, context.subscriptions)
+        this.config.onDidChangeProfiles(this.onConfigurationOrProfilesChanged, this, context.subscriptions)
     }
 
     dispose() {
@@ -39,20 +53,30 @@ export class ClientWindow implements vscode.Disposable {
         this.collectionStatus.dispose()
     }
 
-    verifyConfiguration(config: ConfigurationManager): boolean {
-        this.profileName = config.hasActiveProfile() ? config.activeProfile.get("id") : undefined
+    private onConfigurationOrProfilesChanged() {
+        const currentProfileName = this.config.hasActiveProfile() ? this.config.activeProfile.get("id") : undefined
+
+        if (this.verifyConfiguration() && currentProfileName !== this.profileName) {
+            vscode.commands.executeCommand(Commands.TriggerServerCollection)
+        }
+    }
+
+    verifyConfiguration(): boolean {
+        this.profileName = this.config.hasActiveProfile() ? this.config.activeProfile.get("id") : undefined
         this.logger.info(`Verifying configuration for active profile ${this.profileName}`)
 
         const serverConfIsValid = !!this.profileName
         if (serverConfIsValid) {
-            this.collectionButton.show()
+            if (this.env.hasRelevantProject()) {
+                this.collectionButton.show()
 
-            this.collectionButton.text = "$(cloud-download)"
-            this.collectionButton.command = Commands.TriggerServerCollection
-            this.collectionButton.tooltip = "Trigger vRO hint collection"
-            this.collectionButton.color = undefined
+                this.collectionButton.text = "$(cloud-download)"
+                this.collectionButton.command = Commands.TriggerServerCollection
+                this.collectionButton.tooltip = "Trigger vRO hint collection"
+                this.collectionButton.color = undefined
+            }
 
-            const hostname = config.activeProfile.get("vro.host")
+            const hostname = this.config.activeProfile.get("vro.host")
             this.collectionStatus.text = `$(server) ${this.profileName} (${hostname})`
             this.collectionStatus.tooltip = "Change active profile"
             this.collectionStatus.command = Commands.ChangeProfile
@@ -97,7 +121,7 @@ export class ClientWindow implements vscode.Disposable {
 
         vscode.window.showErrorMessage(errorMessage, "Retry").then(selected => {
             if (selected === "Retry") {
-                vscode.commands.executeCommand(Commands.TriggerServerCollection, this)
+                vscode.commands.executeCommand(Commands.TriggerServerCollection)
             }
         })
     }

--- a/extension/src/client/ui/index.ts
+++ b/extension/src/client/ui/index.ts
@@ -3,5 +3,4 @@
  * SPDX-License-Identifier: MIT
  */
 
-export * from "./ClientWindow"
-export * from "./MultiStepInput"
+export * from "./StatusBarController"

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -15,7 +15,7 @@ import * as lang from "./client/lang"
 import * as lint from "./client/lint"
 import * as manager from "./client/manager"
 import * as provider from "./client/provider"
-import { ClientWindow } from "./client/ui"
+import * as ui from "./client/ui"
 
 const logger = Logger.get("extension")
 let langServices: lang.LanguageServices
@@ -25,20 +25,21 @@ export async function activate(context: vscode.ExtensionContext) {
     Logger.setup(getLoggingChannel(), config.get<LogLevel>("log"))
 
     logger.info("\n\n=== Activating vRealize Developer Tools ===\n")
-    const window = new ClientWindow(config.get("maven.profile"), context)
-    context.subscriptions.push(window)
 
-    const registry = new ModuleRegistry(context, window)
-    registry.registerModules(lang)
+    const registry = new ModuleRegistry(context)
+    registry.registerModules(manager, lang)
 
-    // register and initialize the language services before the rest of the modules
     langServices = registry.get(lang.LanguageServices)
     await langServices.initialize()
 
-    registry.registerModules(manager, command, lint, provider)
+    const configManager = registry.get(manager.ConfigurationManager)
+    configManager.forceLoadProfiles() // initial load and send to LS
 
-    if (window.verifyConfiguration(registry.get(manager.ConfigurationManager))) {
-        vscode.commands.executeCommand(Commands.TriggerServerCollection, window)
+    registry.registerModules(ui, command, lint, provider)
+
+    const statusBar = registry.get(ui.StatusBarController)
+    if (statusBar.verifyConfiguration()) {
+        vscode.commands.executeCommand(Commands.TriggerServerCollection)
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -441,6 +441,7 @@
     "vro-language-server": "language-server/out/public"
   },
   "devDependencies": {
+    "@nblagoev/pull-release-notes": "^1.2.2",
     "@octokit/rest": "^16.27.3",
     "@types/adm-zip": "^0.4.32",
     "@types/chokidar": "~1.7.5",
@@ -475,7 +476,6 @@
     "minimist": "^1.2.0",
     "prettier": "^1.19.1",
     "publish-release": "^1.6.0",
-    "pull-release-notes": "^1.2.1",
     "ts-jest": "^24.1.0",
     "typescript": "~3.7.2",
     "vsce": "^1.69.0"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "engines": {
     "node": ">=10.0.0",
-    "vscode": "^1.32.0"
+    "vscode": "^1.40.0"
   },
   "categories": [
     "Programming Languages"
@@ -454,7 +454,7 @@
     "@types/request-promise-native": "^1.0.17",
     "@types/semver": "^6.0.0",
     "@types/tmp": "^0.1.0",
-    "@types/vscode": "^1.32.0",
+    "@types/vscode": "1.40.0",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
     "@typescript-eslint/parser": "^2.7.0",
     "codecov": "^3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,15 +305,14 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@octokit/endpoint@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-4.0.0.tgz#97032a6690ef1cf9576ab1b1582c0ac837e3b5b6"
-  integrity sha512-b8sptNUekjREtCTJFpOfSIL4SKh65WaakcyxWzRcSPOk5RxkZJ/S8884NGZFxZ+jCB2rDURU66pSHn14cVgWVg==
+"@nblagoev/pull-release-notes@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@nblagoev/pull-release-notes/-/pull-release-notes-1.2.2.tgz#e4a0c1c8306b5acdca629081f329facc91d48515"
+  integrity sha512-avWDzOTc0N3U8gMu1BedJAMcINVT7/DvkVGbSUno9W42PfD1ulwK7/UsC32+CwR0reGrquX5Qc9ZrGkwvNH+9g==
   dependencies:
-    deepmerge "3.2.0"
-    is-plain-object "^2.0.4"
-    universal-user-agent "^2.0.1"
-    url-template "^2.0.8"
+    "@octokit/rest" "^16.35.0"
+    moment "^2.24.0"
+    yargs "^15.0.2"
 
 "@octokit/endpoint@^5.1.0":
   version "5.1.4"
@@ -325,6 +324,15 @@
     universal-user-agent "^2.1.0"
     url-template "^2.0.8"
 
+"@octokit/endpoint@^5.5.0":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-5.5.1.tgz#2eea81e110ca754ff2de11c79154ccab4ae16b3f"
+  integrity sha512-nBFhRUb5YzVTCX/iAK1MgQ4uWo89Gu0TH00qQHoYRCsE12dWcG1OiLd7v2EIo2+tpUKPMOQ62QFy9hy9Vg2ULg==
+  dependencies:
+    "@octokit/types" "^2.0.0"
+    is-plain-object "^3.0.0"
+    universal-user-agent "^4.0.0"
+
 "@octokit/request-error@^1.0.1", "@octokit/request-error@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-1.0.2.tgz#e6dbc5be13be1041ef8eca9225520982add574cf"
@@ -332,18 +340,6 @@
   dependencies:
     deprecation "^2.0.0"
     once "^1.4.0"
-
-"@octokit/request@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-3.0.0.tgz#304a279036b2dc89e7fba7cb30c9e6a9b1f4d2df"
-  integrity sha512-DZqmbm66tq+a9FtcKrn0sjrUpi0UaZ9QPUCxxyk/4CJ2rseTMpAWRf6gCwOSUCzZcx/4XVIsDk+kz5BVdaeenA==
-  dependencies:
-    "@octokit/endpoint" "^4.0.0"
-    deprecation "^1.0.1"
-    is-plain-object "^2.0.4"
-    node-fetch "^2.3.0"
-    once "^1.4.0"
-    universal-user-agent "^2.0.1"
 
 "@octokit/request@^4.0.1":
   version "4.1.0"
@@ -358,23 +354,19 @@
     once "^1.4.0"
     universal-user-agent "^2.1.0"
 
-"@octokit/rest@^16.19.0":
-  version "16.25.0"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.25.0.tgz#1111dc2b2058bc77442fd7fbd295dab3991b62bf"
-  integrity sha512-QKIzP0gNYjyIGmY3Gpm3beof0WFwxFR+HhRZ+Wi0fYYhkEUvkJiXqKF56Pf5glzzfhEwOrggfluEld5F/ZxsKw==
+"@octokit/request@^5.2.0":
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.3.1.tgz#3a1ace45e6f88b1be4749c5da963b3a3b4a2f120"
+  integrity sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==
   dependencies:
-    "@octokit/request" "3.0.0"
-    atob-lite "^2.0.0"
-    before-after-hook "^1.4.0"
-    btoa-lite "^1.0.0"
-    deprecation "^1.0.1"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
-    lodash.uniq "^4.5.0"
-    octokit-pagination-methods "^1.1.0"
+    "@octokit/endpoint" "^5.5.0"
+    "@octokit/request-error" "^1.0.1"
+    "@octokit/types" "^2.0.0"
+    deprecation "^2.0.0"
+    is-plain-object "^3.0.0"
+    node-fetch "^2.3.0"
     once "^1.4.0"
-    universal-user-agent "^2.0.0"
-    url-template "^2.0.8"
+    universal-user-agent "^4.0.0"
 
 "@octokit/rest@^16.27.3":
   version "16.27.3"
@@ -394,6 +386,31 @@
     once "^1.4.0"
     universal-user-agent "^2.0.0"
     url-template "^2.0.8"
+
+"@octokit/rest@^16.35.0":
+  version "16.35.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-16.35.0.tgz#7ccc1f802f407d5b8eb21768c6deca44e7b4c0d8"
+  integrity sha512-9ShFqYWo0CLoGYhA1FdtdykJuMzS/9H6vSbbQWDX4pWr4p9v+15MsH/wpd/3fIU+tSxylaNO48+PIHqOkBRx3w==
+  dependencies:
+    "@octokit/request" "^5.2.0"
+    "@octokit/request-error" "^1.0.2"
+    atob-lite "^2.0.0"
+    before-after-hook "^2.0.0"
+    btoa-lite "^1.0.0"
+    deprecation "^2.0.0"
+    lodash.get "^4.4.2"
+    lodash.set "^4.3.2"
+    lodash.uniq "^4.5.0"
+    octokit-pagination-methods "^1.1.0"
+    once "^1.4.0"
+    universal-user-agent "^4.0.0"
+
+"@octokit/types@^2.0.0":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.0.2.tgz#0888497f5a664e28b0449731d5e88e19b2a74f90"
+  integrity sha512-StASIL2lgT3TRjxv17z9pAqbnI7HGu9DrJlg3sEBFfCLaMEqp+O3IQPUF6EZtQ4xkAu2ml6kMBBCtGxjvmtmuQ==
+  dependencies:
+    "@types/node" ">= 8"
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -506,6 +523,11 @@
     "@types/events" "*"
     "@types/node" "*"
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -602,6 +624,11 @@
   version "12.0.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.4.tgz#46832183115c904410c275e34cf9403992999c32"
   integrity sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==
+
+"@types/node@>= 8":
+  version "12.12.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
+  integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
 
 "@types/node@^10.1.0":
   version "10.12.26"
@@ -871,6 +898,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
+  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
 
 ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
@@ -1211,6 +1246,11 @@ before-after-hook@^1.4.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-1.4.0.tgz#2b6bf23dca4f32e628fd2747c10a37c74a4b484d"
   integrity sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg==
 
+before-after-hook@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
+  integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
@@ -1512,6 +1552,15 @@ cliui@^5.0.0:
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
 
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
 clone-buffer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clone-buffer/-/clone-buffer-1.0.0.tgz#e3e25b207ac4e701af721e2cb5a16792cac3dc58"
@@ -1591,10 +1640,22 @@ color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-support@^1.1.3:
   version "1.1.3"
@@ -1842,11 +1903,6 @@ denodeify@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/denodeify/-/denodeify-1.2.1.tgz#3a36287f5034e699e7577901052c2e6c94251631"
   integrity sha1-OjYof1A05pnnV3kBBSwubJQlFjE=
-
-deprecation@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-1.0.1.tgz#2df79b79005752180816b7b6e079cbd80490d711"
-  integrity sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg==
 
 deprecation@^2.0.0:
   version "2.0.0"
@@ -2619,6 +2675,14 @@ find-up@^3.0.0:
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 findup-sync@^2.0.0:
   version "2.0.0"
@@ -4430,6 +4494,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -5275,7 +5346,7 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-name@^3.0.0:
+os-name@^3.0.0, os-name@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/os-name/-/os-name-3.1.0.tgz#dec19d966296e1cd62d701a5a66ee1ddeae70801"
   integrity sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==
@@ -5327,6 +5398,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
+  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -5340,6 +5418,13 @@ p-locate@^3.0.0:
   integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
   dependencies:
     p-limit "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
 
 p-reduce@^1.0.0:
   version "1.0.0"
@@ -5447,6 +5532,11 @@ path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
   integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -5725,15 +5815,6 @@ publish-release@^1.3.2, publish-release@^1.6.0:
     request "^2.54.0"
     single-line-log "^0.4.1"
     string-editor "^0.1.0"
-
-pull-release-notes@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pull-release-notes/-/pull-release-notes-1.2.1.tgz#d6e8361a92286ea2beea3284da4da4a5d6e297cf"
-  integrity sha512-eaz1qKNx06dB0vYtnTqUNMOFGETy+O97XLE1qkYPYE2CQRVZQHQRL97V5SUJ8eovCMP2Z/y3leSavXh9QCuHpw==
-  dependencies:
-    "@octokit/rest" "^16.19.0"
-    moment "^2.24.0"
-    yargs "^14.0.0"
 
 pump@^2.0.0:
   version "2.0.1"
@@ -6536,7 +6617,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
@@ -7039,7 +7120,7 @@ unique-stream@^2.0.2:
     json-stable-stringify-without-jsonify "^1.0.1"
     through2-filter "^3.0.0"
 
-universal-user-agent@^2.0.0, universal-user-agent@^2.0.1:
+universal-user-agent@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-2.0.3.tgz#9f6f09f9cc33de867bb720d84c08069b14937c6c"
   integrity sha512-eRHEHhChCBHrZsA4WEhdgiOKgdvgrMIHwnwnqD0r5C6AO8kwKcG7qSku3iXdhvHL3YvsS9ZkSGN8h/hIpoFC8g==
@@ -7052,6 +7133,13 @@ universal-user-agent@^2.1.0:
   integrity sha512-8itiX7G05Tu3mGDTdNY2fB4KJ8MgZLS54RdG6PkkfwMAavrXu1mV/lls/GABx9O3Rw4PnTtasxrvbMQoBYY92Q==
   dependencies:
     os-name "^3.0.0"
+
+universal-user-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-4.0.0.tgz#27da2ec87e32769619f68a14996465ea1cb9df16"
+  integrity sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==
+  dependencies:
+    os-name "^3.1.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -7394,6 +7482,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -7469,10 +7566,10 @@ yargs-parser@^13.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs-parser@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-15.0.0.tgz#cdd7a97490ec836195f59f3f4dbe5ea9e8f75f08"
-  integrity sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
@@ -7500,22 +7597,22 @@ yargs@^13.3.0:
     y18n "^4.0.0"
     yargs-parser "^13.1.1"
 
-yargs@^14.0.0:
-  version "14.2.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.0.tgz#f116a9242c4ed8668790b40759b4906c276e76c3"
-  integrity sha512-/is78VKbKs70bVZH7w4YaZea6xcJWOAwkhbR0CFuZBmYtfTYF0xjGJF43AYd8g2Uii1yJwmS5GR2vBmrc32sbg==
+yargs@^15.0.2:
+  version "15.0.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.0.2.tgz#4248bf218ef050385c4f7e14ebdf425653d13bd3"
+  integrity sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==
   dependencies:
-    cliui "^5.0.0"
+    cliui "^6.0.0"
     decamelize "^1.2.0"
-    find-up "^3.0.0"
+    find-up "^4.1.0"
     get-caller-file "^2.0.1"
     require-directory "^2.1.1"
     require-main-filename "^2.0.0"
     set-blocking "^2.0.0"
-    string-width "^3.0.0"
+    string-width "^4.2.0"
     which-module "^2.0.0"
     y18n "^4.0.0"
-    yargs-parser "^15.0.0"
+    yargs-parser "^16.1.0"
 
 yargs@^7.1.0:
   version "7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,7 +660,7 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.3.tgz#7f226d67d654ec9070e755f46daebf014628e9d9"
   integrity sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==
 
-"@types/vscode@^1.32.0":
+"@types/vscode@1.40.0":
   version "1.40.0"
   resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.40.0.tgz#47d19e9e32da512c986f579fe6afbc8d3e6e0c55"
   integrity sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

* Start the vRO Language Server only if a valid vRealize project is opened
* Show vRealize tasks only if a valid vRealize project is opened
* Specialize the ClientWindow class to control only the status bar and rename it to StatusBarController
* Use event-based approach to notify and react on maven profile changes

### Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [X] I have tested against live vRO/vRA, if applicable
- [ ] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested using a vRO/vRA mixed project and a random non-vRealize project

### Release Notes

Irrelevant features of the extension will not load if a non-vRealize project is opened

