### PR TITLE
Support highly nested project structure when generating build tasks

### DIFF
--- a/extension/src/client/provider/task/TaskProvider.ts
+++ b/extension/src/client/provider/task/TaskProvider.ts
@@ -126,7 +126,8 @@ export class TaskProvider implements vscode.TaskProvider, Registrable {
 
         if (pomFile.isBase && pomFile.modules.length > 0) {
             pomFile.modules.forEach(module => {
-                this.includeDefaultTasks(folder, module, tasks, excludePatterns)
+                const dirname = subfolder ? path.basename(path.dirname(pomFile.filePath)) : undefined
+                this.includeDefaultTasks(folder, dirname ? `${dirname}/${module}` : module, tasks, excludePatterns)
             })
         }
     }


### PR DESCRIPTION
### Description

Fixed a bug where it is not possible to build a list of vRealize tasks (Cmd+Shift+B) for composite project of multiple nested maven modules.

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have tested against live vRO/vRA, if applicable
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [ ] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested using a project with the following structure.
* **someprj** (pom.xml - _base-package_)
	* **common** (pom.xml - _typescript-project_)
	* **cm** (pom.xml - _base-package_)
		* **vra** (pom.xml - _vra-ng-package_)
		* **vro** (pom.xml - _typescript-project_)
	* **pod** (pom.xml - _base-package_)
		* **vra** (pom.xml - _vra-ng-package_)
		* **vro** (pom.xml - _typescript-project_)


### Release Notes
Support highly nested project structure when generating build tasks
