### PR TITLE
update gulpfile

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,8 +16,8 @@ const rootPath = __dirname
 const nodeModulesPathPrefix = path.resolve("./node_modules")
 const isWin = /^win/.test(process.platform)
 const jest = path.join(nodeModulesPathPrefix, ".bin", "jest") + (isWin ? ".cmd" : "")
-const pbjs = path.join(nodeModulesPathPrefix, "protobufjs", "bin", "pbjs")
-const pbts = path.join(nodeModulesPathPrefix, "protobufjs", "bin", "pbts")
+const pbjs = path.join(nodeModulesPathPrefix,  ".bin", "pbjs")
+const pbts = path.join(nodeModulesPathPrefix,  ".bin", "pbts")
 const vsce = path.join(nodeModulesPathPrefix, ".bin", "vsce")
 const tsc = path.join(nodeModulesPathPrefix, ".bin", "tsc")
 
@@ -176,7 +176,7 @@ gulp.task("default", gulp.series("watch"))
 function exec(cmd, args, cwd, stdio = "inherit") {
     var cmdString = `${cmd} ${args.join(" ")}`
     log(cmdString)
-    var result = cp.spawnSync(cmd, args, { stdio, cwd })
+    var result = cp.spawnSync(cmd, args, {shell:true, stdio, cwd })
     if (result.status != 0) {
         throw new Error(`Command "${cmdString}" exited with code ` + result.status)
     }


### PR DESCRIPTION
Signed-off-by: Valentin <vmanasiev@vmware.com>

<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
The build fails on windows machines for two reasons 
 - The child process does not always return  return code ( returns null),  adding parameter shell:true fixes this issue
- The pbjs and pbts scripts found in the  protobufjs/bin folder are only shell compatible. There are two ways to fix the issue. Either execute those with node and pass pbjs path as parameter or change the path to  nodejs_modules/.bin/pbjs    where you can also find   pbjs.cmd and pbts.cmd  (just as it is done with tsc and vsce