### PR TITLE
fix windows command for sub projects + add maven type typescript-proj…

### DIFF
--- a/common/src/maven/PomFile.ts
+++ b/common/src/maven/PomFile.ts
@@ -12,6 +12,7 @@ export class PomFile {
         "actions-package": "com.vmware.pscoe.o11n",
         "xml-package": "com.vmware.pscoe.o11n",
         "typescript-project": "com.vmware.pscoe.o11n",
+        "typescript-project-all": "com.vmware.pscoe.o11n",
         "vra-package": "com.vmware.pscoe.vra",
         "vra-ng-package": "com.vmware.pscoe.vra-ng"
     }

--- a/extension/src/client/constants.ts
+++ b/extension/src/client/constants.ts
@@ -95,6 +95,7 @@ export enum OutputChannels {
 
 export enum ProjectArchetypes {
     TypeScript = "com.vmware.pscoe.o11n:typescript-project",
+    TypeScriptAll = "com.vmware.pscoe.o11n:typescript-project-all",
     Base = "com.vmware.pscoe.o11n:base-package",
     Actions = "com.vmware.pscoe.o11n:actions-package",
     Xml = "com.vmware.pscoe.o11n:xml-package",

--- a/extension/src/client/provider/task/DefaultTasksJson.ts
+++ b/extension/src/client/provider/task/DefaultTasksJson.ts
@@ -7,8 +7,32 @@
 
 import { ProjectArchetypes } from "../../constants"
 
-export const TASKS_BY_TOOLCHAIN_PARENT = {
-    [ProjectArchetypes.TypeScript]: [
+export interface VrealizeTaskConfiguration {
+    label: string
+    command: string
+    windows?: { command: string }
+    linux?: { command: string }
+    osx?: { command: string }
+}
+
+export const TASKS_BY_TOOLCHAIN_PARENT: Record<ProjectArchetypes, VrealizeTaskConfiguration[]> = {
+     [ProjectArchetypes.TypeScript]: [
+        {
+            label: "Push",
+            windows: {
+                command:
+                    'mvn clean package vrealize:push -DincludeDependencies=true -DskipTests -P${config:vrdev.maven.profile} -D"vro.packageImportConfigurationAttributeValues=false"'
+            },
+            command:
+                "mvn clean package vrealize:push -DincludeDependencies=true -DskipTests -P${config:vrdev.maven.profile} -Dvro.packageImportConfigurationAttributeValues=false"
+        },
+        {
+            label: "Build",
+            command: "mvn clean package"
+        }
+    ],
+
+    [ProjectArchetypes.TypeScriptAll]: [
         {
             label: "Push",
             windows: {


### PR DESCRIPTION
-Fixing a problem where the -pl parameter was not applied to windows command lines
-Adding new typescript-project-all type
Signed-off-by: Valentin <vmanasiev@vmware.com>

<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
1) default task creation
- The task definition was extended previously to contain specific lines for different os type.
- As a result further manipulations like adding the -pl parameter were done only on common command line.
- I have split the default task configuration concern with the default task creation/parsing
 
2) matching configured task with tasks.json.
- The tasks where matched by name. But VSCode adds the task type to the task name when storing it in tasks.json.  So I extended the matching pattern to include `${type}: ${name}
- This does no solve the problem where you see only a single task when you define it in tasks.json. Which is managed partially outside the Task Provider and seems to be out of control.  But if you delete the extra parameters like "group" and "problemMatcher"  the mixed tasks display starts to work again.

3) add the new project type: "typescript-project-all"
