### PR TITLE
Keep vRA blueprint metadata like name, id and description in the YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > and [vRealize Automation](https://www.vmware.com/products/vrealize-automation.html) content.
 
 [![Visual Studio Marketplace Version](https://img.shields.io/visual-studio-marketplace/v/vmware-pscoe.vrealize-developer-tools.svg?label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=vmware-pscoe.vrealize-developer-tools)
-[![Build Status](https://img.shields.io/github/workflow/status/vmware/vrealize-developer-tools/Build/master.svg?logo=github)](https://github.com/vmware/vrealize-developer-tools/actions)
+[![Build Status](https://github.com/vmware/vrealize-developer-tools/workflows/Build/badge.svg)](https://github.com/vmware/vrealize-developer-tools/actions)
 [![Dependencies Status](https://david-dm.org/vmware/vrealize-developer-tools/status.svg)](https://david-dm.org/vmware/vrealize-developer-tools)
 [![Coverage Status](https://codecov.io/gh/vmware/vrealize-developer-tools/branch/master/graph/badge.svg)](https://codecov.io/gh/vmware/vrealize-developer-tools/)
 

--- a/common/src/rest/VraNgRestClient.ts
+++ b/common/src/rest/VraNgRestClient.ts
@@ -200,11 +200,11 @@ export class VraNgRestClient {
         return this.unwrapPages(blueprints, "/blueprint/api/blueprints")
     }
 
-    async createBlueprint(body: { name: string; projectId: string; content: string }): Promise<any> {
+    async createBlueprint(body: { name: string; projectId: string; content: string, description: string }): Promise<any> {
         return this.send("POST", "/blueprint/api/blueprints", { body })
     }
 
-    async updateBlueprint(id: string, body: { name: string; projectId: string; content: string }): Promise<void> {
+    async updateBlueprint(id: string, body: { name: string; projectId: string; content: string, description: string }): Promise<void> {
         return this.send("PUT", `/blueprint/api/blueprints/${id}`, { body })
     }
 

--- a/extension/src/client/command/CreateBlueprint.ts
+++ b/extension/src/client/command/CreateBlueprint.ts
@@ -44,10 +44,11 @@ export class CreateBlueprint extends BaseVraCommand {
         })
 
         if (!newFile) {
-            return Promise.reject("Save dialog was canceled")
+            this.logger.warn("Save dialog was canceled")
+            return
         }
 
-        await vscode.workspace.fs.writeFile(newFile, Buffer.from(`name: ${blueprintName}\ninputs: {}\nresources:\n`))
+        await vscode.workspace.fs.writeFile(newFile, Buffer.from(`name: ${blueprintName}\ndescription: ""\ncontent:\n  formatVersion: 1\n  inputs: {}\n  resources:\n`))
         await vscode.window.showTextDocument(newFile, { preview: false })
 
         vscode.window

--- a/package.json
+++ b/package.json
@@ -541,6 +541,7 @@
     "@types/fs-extra": "~5.0.4",
     "@types/glob": "7.1.1",
     "@types/jest": "^24.9.1",
+    "@types/jwt-decode": "^2.2.1",
     "@types/keytar": "^4.4.2",
     "@types/lodash": "^4.14.149",
     "@types/micromatch": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -571,7 +571,7 @@
     "prettier": "^1.19.1",
     "ts-jest": "^25.0.0",
     "typescript": "~3.7.2",
-    "vsce": "^1.69.0"
+    "vsce": "^1.77.0"
   },
   "dependencies": {
     "adm-zip": "^0.4.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,6 +676,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/jwt-decode@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
+  integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
+
 "@types/keytar@^4.4.2":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@types/keytar/-/keytar-4.4.2.tgz#49ef917d6cbb4f19241c0ab50cd35097b5729b32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1927,11 +1927,6 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha1-V29d/GOuGhkv8ZLYrTr2MImRtlE=
 
-didyoumean@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.1.tgz#e92edfdada6537d484d73c0172fd1eba0c4976ff"
-  integrity sha1-6S7f2tplN9SE1zwBcv0eugxJdv8=
-
 diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
@@ -2064,6 +2059,11 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 error-ex@^1.2.0:
   version "1.3.2"
@@ -4307,7 +4307,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13:
+lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13:
   version "4.17.13"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.13.tgz#0bdc3a6adc873d2f4e0c4bac285df91b64fc7b93"
   integrity sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==
@@ -4367,13 +4367,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it@^8.3.1:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
-  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
   dependencies:
     argparse "^1.0.7"
-    entities "~1.1.1"
+    entities "~2.0.0"
     linkify-it "^2.0.0"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
@@ -6681,20 +6681,20 @@ vinyl@^2.0.0:
     remove-trailing-separator "^1.0.1"
     replace-ext "^1.0.0"
 
-vsce@^1.69.0:
-  version "1.69.0"
-  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.69.0.tgz#3d862a42103192c1c79724d9fcb384a61e859d25"
-  integrity sha512-mRSlfrTb6rw8UVFZpJ3w++s0wd4S/OPjhUgSmspjiuy96HQEqOdpPF6S/ssYs0SqE/hMh6grmAYE0MLUmi1w4Q==
+vsce@^1.77.0:
+  version "1.77.0"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.77.0.tgz#21364d3e63095b2f54e0f185445e8ff6ab614602"
+  integrity sha512-8vOTCI3jGmOm0JJFu/BMAbqxpaSuka4S3hV9E6K5aWBUsDM1SGFExkIxHblnsI8sls43xP61DHorYT+K0F+GFA==
   dependencies:
     azure-devops-node-api "^7.2.0"
     chalk "^2.4.2"
     cheerio "^1.0.0-rc.1"
     commander "^2.8.1"
     denodeify "^1.2.1"
-    didyoumean "^1.2.1"
     glob "^7.0.6"
-    lodash "^4.17.10"
-    markdown-it "^8.3.1"
+    leven "^3.1.0"
+    lodash "^4.17.15"
+    markdown-it "^10.0.0"
     mime "^1.3.4"
     minimatch "^3.0.3"
     osenv "^0.1.3"


### PR DESCRIPTION
### Description
Include metadata in the vRA blueprint YAML, in addition to the content, to make it compatible with latest versions of vRBT.
```yaml
id: 029be221-7da3-4438-a86a-6a07db20e718
name: Blueprint Name
content:
  formatVersion: 1
  inputs: {}
  resources: {}
description: ""
requestScopeOrg: false
```

### Testing

Tested against vRA Cloud