### PR TITLE
IAC-805 Lazy Load of vRO Inventory Items

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
     "**/build/azure-pipelines/**/*.yml": "azure-pipelines"
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": ["javascript", "typescript"],
 

--- a/extension/src/client/command/DeletePackage.ts
+++ b/extension/src/client/command/DeletePackage.ts
@@ -26,7 +26,7 @@ export class DeletePackage extends Command<void> {
 
     constructor(config: ConfigurationManager, environment: EnvironmentManager) {
         super()
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     async execute(context: vscode.ExtensionContext, node: PackageNode): Promise<void> {

--- a/extension/src/client/command/FetchWorkflowSchema.ts
+++ b/extension/src/client/command/FetchWorkflowSchema.ts
@@ -25,7 +25,7 @@ export class FetchWorkflowSchema extends Command<void> {
 
     constructor(config: ConfigurationManager, environment: EnvironmentManager) {
         super()
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     async execute(context: vscode.ExtensionContext, node: WorkflowNode): Promise<void> {

--- a/extension/src/client/command/RunAction.ts
+++ b/extension/src/client/command/RunAction.ts
@@ -307,7 +307,7 @@ class ActionRunner {
         if (!fs.existsSync(storagePath)) {
             fs.mkdirSync(storagePath)
         }
-
+        // exec
         await this.mavenProxy.copyDependency(
             "com.vmware.pscoe.o11n",
             "exec",

--- a/extension/src/client/command/RunAction.ts
+++ b/extension/src/client/command/RunAction.ts
@@ -225,7 +225,7 @@ class ActionRunner {
     private executionToken: string
 
     constructor(config: ConfigurationManager, private environment: EnvironmentManager) {
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
         this.mavenProxy = new MavenCliProxy(environment, config.vrdev.maven, this.logger)
     }
 

--- a/extension/src/client/command/ShowActions.ts
+++ b/extension/src/client/command/ShowActions.ts
@@ -22,7 +22,7 @@ export class ShowActions extends Command<void> {
 
     constructor(environment: EnvironmentManager, private config: ConfigurationManager) {
         super()
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     async execute(context: vscode.ExtensionContext): Promise<void> {

--- a/extension/src/client/command/ShowConfigurations.ts
+++ b/extension/src/client/command/ShowConfigurations.ts
@@ -22,7 +22,7 @@ export class ShowConfigurations extends Command<void> {
 
     constructor(environment: EnvironmentManager, config: ConfigurationManager) {
         super()
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     async execute(context: vscode.ExtensionContext): Promise<void> {

--- a/extension/src/client/command/ShowResources.ts
+++ b/extension/src/client/command/ShowResources.ts
@@ -22,7 +22,7 @@ export class ShowResources extends Command<void> {
 
     constructor(environment: EnvironmentManager, config: ConfigurationManager) {
         super()
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     async execute(context: vscode.ExtensionContext): Promise<void> {

--- a/extension/src/client/command/ShowWorkflows.ts
+++ b/extension/src/client/command/ShowWorkflows.ts
@@ -22,7 +22,7 @@ export class ShowWorkflows extends Command<void> {
 
     constructor(environment: EnvironmentManager, config: ConfigurationManager) {
         super()
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     async execute(context: vscode.ExtensionContext): Promise<void> {

--- a/extension/src/client/command/TriggerCollection.ts
+++ b/extension/src/client/command/TriggerCollection.ts
@@ -7,7 +7,7 @@ import { AutoWire, Logger, sleep } from "@vmware/vrdt-common"
 import { remote } from "@vmware/vro-language-server"
 import * as vscode from "vscode"
 
-import { Commands } from "../constants"
+import { Commands, LanguageServerConfig } from "../constants"
 import { LanguageServices } from "../lang"
 import { Command } from "./Command"
 
@@ -30,7 +30,7 @@ export class TriggerCollection extends Command<void> {
         const languageClient = this.languageServices.client
 
         if (!languageClient) {
-            this.logger.warn("The vRO language server is not running")
+            this.logger.warn(`The ${LanguageServerConfig.DisplayName} is not running`)
             return
         }
         await vscode.commands.executeCommand(Commands.EventCollectionStart)
@@ -48,15 +48,13 @@ export class TriggerCollection extends Command<void> {
                     while (status && !status.finished) {
                         this.logger.info("Collection status:", status)
                         progress.report(status)
-                        await sleep(1000)
+                        await sleep(LanguageServerConfig.SleepTime)
                         status = await languageClient.sendRequest(remote.server.giveVroCollectionStatus)
                     }
 
                     this.logger.info("Collection finished:", status)
-
                     if (status.error !== undefined) {
                         await vscode.commands.executeCommand(Commands.EventCollectionError, status.error)
-
                         if (status.data.hintsPluginBuild === 0) {
                             vscode.window.showErrorMessage(
                                 "The vRO Hint plug-in is not installed on the configured vRO server"

--- a/extension/src/client/command/TriggerCollection.ts
+++ b/extension/src/client/command/TriggerCollection.ts
@@ -33,7 +33,6 @@ export class TriggerCollection extends Command<void> {
             this.logger.warn("The vRO language server is not running")
             return
         }
-
         await vscode.commands.executeCommand(Commands.EventCollectionStart)
 
         vscode.window.withProgress(

--- a/extension/src/client/constants.ts
+++ b/extension/src/client/constants.ts
@@ -110,3 +110,11 @@ export enum ProjectArchetypes {
     VraNg = "com.vmware.pscoe.vra-ng:vra-ng-package",
     Polyglot = "com.vmware.pscoe.polyglot:polyglot-project"
 }
+
+export enum LanguageServerConfig {
+    Port = 6014,
+    LoadType = "nolazy",
+    NodeType = "node-ipc",
+    DisplayName = "vRO Language Server",
+    SleepTime = 1000
+}

--- a/extension/src/client/lang/LanguageServices.ts
+++ b/extension/src/client/lang/LanguageServices.ts
@@ -10,7 +10,7 @@ import { remote } from "@vmware/vro-language-server"
 import * as vscode from "vscode"
 import * as client from "vscode-languageclient"
 
-import { OutputChannels } from "../constants"
+import { LanguageServerConfig, OutputChannels } from "../constants"
 import { Registrable } from "../Registrable"
 import { ConfigurationManager, EnvironmentManager } from "../system"
 
@@ -82,20 +82,23 @@ export class LanguageServices implements Registrable, vscode.Disposable {
                 ? path.join(module, "dist", "langserver.js")
                 : path.join(module, "out", "server", "langserver.js")
 
-        this.logger.info(`Starting vRO language server on port 6014`)
+        this.logger.info(`Starting vRO language server on port '${LanguageServerConfig.Port}'`)
 
         const serverOptions = {
             run: {
                 module: executable,
                 transport: client.TransportKind.ipc,
-                args: ["--node-ipc"],
+                args: [`--${LanguageServerConfig.NodeType}`],
                 options: { cwd: module }
             },
             debug: {
                 module: executable,
                 transport: client.TransportKind.ipc,
-                args: ["--node-ipc"],
-                options: { cwd: module, execArgv: ["--nolazy", "--inspect=6014"] }
+                args: [`--${LanguageServerConfig.NodeType}`],
+                options: {
+                    cwd: module,
+                    execArgv: [`--${LanguageServerConfig.LoadType}`, `--inspect=${LanguageServerConfig.Port}`]
+                }
             }
         }
 
@@ -119,6 +122,6 @@ export class LanguageServices implements Registrable, vscode.Disposable {
                 ]
             }
         }
-        return new client.LanguageClient("vRO LS", serverOptions, clientOptions)
+        return new client.LanguageClient(LanguageServerConfig.DisplayName, serverOptions, clientOptions)
     }
 }

--- a/extension/src/client/provider/content/ContentProvider.ts
+++ b/extension/src/client/provider/content/ContentProvider.ts
@@ -24,7 +24,7 @@ export class ContentProvider implements vscode.TextDocumentContentProvider, Regi
     private readonly logger = Logger.get("ContentProvider")
 
     constructor(environment: EnvironmentManager, config: ConfigurationManager) {
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     dispose() {

--- a/extension/src/client/provider/explorer/ExplorerProvider.ts
+++ b/extension/src/client/provider/explorer/ExplorerProvider.ts
@@ -33,7 +33,7 @@ export class ExplorerProvider implements vscode.TreeDataProvider<AbstractNode>, 
     readonly onDidChangeTreeData: vscode.Event<AbstractNode | undefined> = this.onDidChangeTreeDataEmitter.event
 
     constructor(environment: EnvironmentManager, private config: ConfigurationManager) {
-        this.restClient = new VroRestClient(config, environment)
+        this.restClient = new VroRestClient(config)
     }
 
     register(context: vscode.ExtensionContext): void {

--- a/extension/src/client/system/ConfigurationManager.ts
+++ b/extension/src/client/system/ConfigurationManager.ts
@@ -23,7 +23,7 @@ import { Registrable } from "../Registrable"
 
 @AutoWire
 export class ConfigurationManager extends BaseConfiguration implements Registrable {
-    private homeDir = process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"] || "~"
+    private homeDir = process.env[process.platform === "win32" ? "USERPROFILE" : "HOME"] ?? "~"
     private readonly logger = Logger.get("ConfigurationManager")
 
     readonly settingsXmlPath: string = path.resolve(this.homeDir, ".m2", "settings.xml")

--- a/extension/src/client/ui/StatusBarController.ts
+++ b/extension/src/client/ui/StatusBarController.ts
@@ -53,14 +53,6 @@ export class StatusBarController implements Registrable, vscode.Disposable {
         this.collectionStatus.dispose()
     }
 
-    private onConfigurationOrProfilesChanged() {
-        const currentProfileName = this.config.hasActiveProfile() ? this.config.activeProfile.get("id") : undefined
-
-        if (this.verifyConfiguration() && currentProfileName !== this.profileName && this.env.hasRelevantProject()) {
-            vscode.commands.executeCommand(Commands.TriggerServerCollection)
-        }
-    }
-
     verifyConfiguration(): boolean {
         this.profileName = this.config.hasActiveProfile() ? this.config.activeProfile.get("id") : undefined
         this.logger.info(`Verifying configuration for active profile ${this.profileName}`)
@@ -94,6 +86,14 @@ export class StatusBarController implements Registrable, vscode.Disposable {
         this.collectionStatus.command = Commands.ChangeProfile
 
         return false
+    }
+
+    private onConfigurationOrProfilesChanged() {
+        const currentProfileName = this.config.hasActiveProfile() ? this.config.activeProfile.get("id") : undefined
+
+        if (this.verifyConfiguration() && currentProfileName !== this.profileName && this.env.hasRelevantProject()) {
+            vscode.commands.executeCommand(Commands.TriggerServerCollection)
+        }
     }
 
     private onCollectionStart() {

--- a/package.json
+++ b/package.json
@@ -525,7 +525,7 @@
         "vrdev.vro.inventory.cache": {
           "type": "boolean",
           "default": true,
-          "description": "Enable / Disable vRO Inventory Caching",
+          "description": "Enable vRO inventory caching (can be used in heavily loaded environments)",
           "scope": "window"
         }
       }

--- a/package.json
+++ b/package.json
@@ -521,6 +521,12 @@
           ],
           "markdownDescription": "Specifies how the _Explorer_ view will display vRO action packages",
           "scope": "window"
+        },
+        "vrdev.vro.inventory.cache": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable / Disable vRO Inventory Caching",
+          "scope": "window"
         }
       }
     },

--- a/packages/node/vrdt-common/src/platform/BaseConfiguration.ts
+++ b/packages/node/vrdt-common/src/platform/BaseConfiguration.ts
@@ -22,20 +22,19 @@ export abstract class BaseConfiguration {
         return this.getActiveProfileImpl()
     }
 
-    get pluginSettings(): VrealizeSettings {
-        return this.vrdev
-    }
-
     private getActiveProfileImpl(): MavenProfileWrapper {
         const profileName = this.vrdev.maven.profile
 
         if (!profileName) {
             throw new Error("There is no currently active maven profile. Set the 'vrdev.maven.profile' setting")
         }
+
         if (!this.allProfiles) {
             throw new Error("There are no vRO profiles in ~/.m2/settings.xml")
         }
+
         const profile = this.allProfiles[profileName]
+
         if (!profile) {
             throw new Error(`Could not find profile '${profileName}' in ~/.m2/settings.xml`)
         }

--- a/packages/node/vrdt-common/src/platform/BaseConfiguration.ts
+++ b/packages/node/vrdt-common/src/platform/BaseConfiguration.ts
@@ -22,19 +22,20 @@ export abstract class BaseConfiguration {
         return this.getActiveProfileImpl()
     }
 
+    get pluginSettings(): VrealizeSettings {
+        return this.vrdev
+    }
+
     private getActiveProfileImpl(): MavenProfileWrapper {
         const profileName = this.vrdev.maven.profile
 
         if (!profileName) {
             throw new Error("There is no currently active maven profile. Set the 'vrdev.maven.profile' setting")
         }
-
         if (!this.allProfiles) {
             throw new Error("There are no vRO profiles in ~/.m2/settings.xml")
         }
-
         const profile = this.allProfiles[profileName]
-
         if (!profile) {
             throw new Error(`Could not find profile '${profileName}' in ~/.m2/settings.xml`)
         }

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -39,9 +39,11 @@ export class VroRestClient {
     private workflows: Workflow[] = []
     private configurations: Configuration[] = []
     private resources: Resource[] = []
+    private isCachingEnabled: boolean
 
     constructor(private settings: BaseConfiguration) {
         this.auth = this.getInitialAuth()
+        this.isCachingEnabled = this.settings?.pluginSettings?.vro?.inventory?.cache ?? false
     }
 
     private get hostname(): string {
@@ -372,8 +374,8 @@ export class VroRestClient {
     }
 
     async getActions(): Promise<Action[]> {
-        // return the cached actions (if any)
-        if (this.actions && Array.isArray(this.actions) && this.actions.length) {
+        // return the cached actions (if any) if caching is enabled
+        if (this.isCachingEnabled && this.actions && Array.isArray(this.actions) && this.actions.length) {
             return this.actions
         }
 
@@ -398,15 +400,17 @@ export class VroRestClient {
             }) as { fqn: string; id: string; version: string }[]
 
         actions.sort((x, y) => x.fqn.localeCompare(y.fqn))
-        // cache the actions in order not to overload vRO
-        this.actions = actions
+        // cache the actions in order not to overload vRO if caching is enabled
+        if (this.isCachingEnabled) {
+            this.actions = actions
+        }
 
         return this.actions
     }
 
     async getWorkflows(): Promise<Workflow[]> {
-        // return the cached workflows (if any)
-        if (this.workflows && Array.isArray(this.workflows) && this.workflows.length) {
+        // return the cached workflows (if any) if caching is enabled
+        if (this.isCachingEnabled && this.workflows && Array.isArray(this.workflows) && this.workflows.length) {
             return this.workflows
         }
 
@@ -432,15 +436,22 @@ export class VroRestClient {
             }) as { name: string; id: string; version: string }[]
 
         workflows.sort((x, y) => x.name.localeCompare(y.name))
-        // cache the workflows
-        this.workflows = workflows
+        // cache the workflows if caching is enabled
+        if (this.isCachingEnabled) {
+            this.workflows = workflows
+        }
 
         return workflows
     }
 
     async getConfigurations(): Promise<Configuration[]> {
-        // return the cached configurations (if any)
-        if (this.configurations && Array.isArray(this.configurations) && this.configurations.length) {
+        // return the cached configurations (if any) if caching is enabled
+        if (
+            this.isCachingEnabled &&
+            this.configurations &&
+            Array.isArray(this.configurations) &&
+            this.configurations.length
+        ) {
             return this.configurations
         }
 
@@ -465,15 +476,17 @@ export class VroRestClient {
             }) as { name: string; id: string; version: string }[]
         configs.sort((x, y) => x.name.localeCompare(y.name))
 
-        // cache the configurations
-        this.configurations = configs
+        // cache the configurations if caching is enabled
+        if (this.isCachingEnabled) {
+            this.configurations = configs
+        }
 
         return configs
     }
 
     async getResources(): Promise<Resource[]> {
-        // return the cached resources (if any)
-        if (this.resources && Array.isArray(this.resources) && this.resources.length) {
+        // return the cached resources (if any) if caching is enabled
+        if (this.isCachingEnabled && this.resources && Array.isArray(this.resources) && this.resources.length) {
             return this.resources
         }
 
@@ -497,15 +510,21 @@ export class VroRestClient {
 
         resources.sort((x, y) => x.name.localeCompare(y.name))
 
-        // cache the resources
-        this.resources = resources
+        // cache the resources if caching is enabled
+        if (this.isCachingEnabled) {
+            this.resources = resources
+        }
 
         return resources
     }
 
     async getRootCategories(categoryType: ApiCategoryType): Promise<ApiElement[]> {
-        // return cached hint root elements (if any) in order to not overload vRO
-        if (this.rootElements?.has(categoryType) && Array.isArray(this.rootElements?.get(categoryType))) {
+        // return cached hint root elements (if any) in order to not overload vRO if caching is enabled
+        if (
+            this.isCachingEnabled &&
+            this.rootElements?.has(categoryType) &&
+            Array.isArray(this.rootElements?.get(categoryType))
+        ) {
             return this.childElements?.get(categoryType) as ApiElement[]
         }
 
@@ -530,15 +549,21 @@ export class VroRestClient {
 
         categories.sort((x, y) => x.name.localeCompare(y.name))
 
-        // cache the hint root elements in order not to overload vRO REST API
-        this.childElements.set(categoryType, categories)
+        // cache the hint root elements in order not to overload vRO REST API if caching is enabled
+        if (this.isCachingEnabled) {
+            this.childElements.set(categoryType, categories)
+        }
 
         return categories
     }
 
     async getChildrenOfCategory(categoryId: string): Promise<ApiElement[]> {
-        // return cached hint child elements (if any) in order to not overload vRO
-        if (this.childElements?.has(categoryId) && Array.isArray(this.childElements?.get(categoryId))) {
+        // return cached hint child elements (if any) in order to not overload vRO if caching is enabled
+        if (
+            this.isCachingEnabled &&
+            this.childElements?.has(categoryId) &&
+            Array.isArray(this.childElements?.get(categoryId))
+        ) {
             return this.childElements?.get(categoryId) as ApiElement[]
         }
 
@@ -565,15 +590,21 @@ export class VroRestClient {
 
         children.sort((x, y) => x.name.localeCompare(y.name))
 
-        // cache the hint child elements in order not to overload vRO REST API
-        this.childElements.set(categoryId, children)
+        // cache the hint child elements in order not to overload vRO REST API if caching is enabled
+        if (this.isCachingEnabled) {
+            this.childElements.set(categoryId, children)
+        }
 
         return children
     }
 
     async getChildrenOfCategoryWithDetails(categoryId: string): Promise<HintAction[]> {
-        // return cached hint actions (if any) in order to not overload vRO REST API
-        if (this.hintActions?.has(categoryId) && Array.isArray(this.hintActions?.get(categoryId))) {
+        // return cached hint actions (if any) in order to not overload vRO REST API if caching is enabled
+        if (
+            this.isCachingEnabled &&
+            this.hintActions?.has(categoryId) &&
+            Array.isArray(this.hintActions?.get(categoryId))
+        ) {
             return this.hintActions?.get(categoryId) as HintAction[]
         }
 
@@ -604,8 +635,10 @@ export class VroRestClient {
             } as HintAction
         })
         children.sort((x, y) => x.name.localeCompare(y.name))
-        // cache the hint actions in order not to overload vRO REST API
-        this.hintActions.set(categoryId, children)
+        // cache the hint actions in order not to overload vRO REST API if caching is enabled in config
+        if (this.isCachingEnabled) {
+            this.hintActions.set(categoryId, children)
+        }
 
         return children
     }
@@ -636,7 +669,7 @@ export class VroRestClient {
     }
 
     async getInventoryItems(href?: string): Promise<InventoryElement[]> {
-        const responseJson: ContentChildrenResponse = await this.send("GET", href || "inventory")
+        const responseJson: ContentChildrenResponse = await this.send("GET", href ?? "inventory")
         const children = responseJson.relations.link
             .map(child => {
                 if (!child.attributes) {

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -18,6 +18,7 @@ import {
     ContentChildrenResponse,
     ContentLinksResponse,
     InventoryElement,
+    LinkItem,
     LogMessage,
     Resource,
     Version,
@@ -86,7 +87,7 @@ export class VroRestClient {
         this.logger.info("Initial authentication...")
         let auth: Auth
 
-        await sleep(1000) // to properly initialize the components
+        await sleep(3000) // to properly initialize the components
 
         let refreshToken = this.refreshToken
         switch (this.authMethod.toLowerCase()) {
@@ -535,18 +536,19 @@ export class VroRestClient {
             `categories?isRoot=true&categoryType=${categoryType}`
         )
         const categories = responseJson.link
-            .map(child => {
-                const name = child.attributes.find(att => att.name === "name")
-                const id = child.attributes.find(att => att.name === "id")
+            .map((item: LinkItem) => {
+                const name = item.attributes.find(att => att.name === "name")
+                const id = item.attributes.find(att => att.name === "id")
                 return {
-                    name: name ? name.value : undefined,
-                    id: id ? id.value : undefined,
+                    name: name?.value ?? undefined,
+                    id: id?.value ?? undefined,
                     type: categoryType,
-                    rel: child.rel
+                    rel: item?.rel,
+                    description: item?.description?.value ?? undefined
                 }
             })
-            .filter(val => {
-                return val.name !== undefined && val.id !== undefined
+            .filter(item => {
+                return item.name !== undefined && item.id !== undefined
             }) as ApiElement[]
 
         categories.sort((x, y) => x.name.localeCompare(y.name))

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -43,7 +43,7 @@ export class VroRestClient {
 
     constructor(private settings: BaseConfiguration) {
         this.auth = this.getInitialAuth()
-        this.isCachingEnabled = this.settings?.pluginSettings?.vro?.inventory?.cache ?? false
+        this.isCachingEnabled = this.settings?.vrdev?.vro?.inventory?.cache ?? false
     }
 
     private get hostname(): string {

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -43,7 +43,7 @@ export class VroRestClient {
 
     constructor(private settings: BaseConfiguration) {
         this.auth = this.getInitialAuth()
-        this.isCachingEnabled = this.settings?.vrdev?.vro?.inventory?.cache ?? false
+        this.loadCacheConfiguration()
     }
 
     private get hostname(): string {
@@ -182,6 +182,8 @@ export class VroRestClient {
         options?: Partial<request.OptionsWithUrl>
     ): Promise<T> {
         const url = route.indexOf("://") > 0 ? route : `https://${this.hostname}:${this.port}/vco/api/${route}`
+        // reload the cache configuration in order cache to take effect when settings are changed
+        this.loadCacheConfiguration()
         return request({
             headers: {
                 "Accept": "application/json",
@@ -675,15 +677,12 @@ export class VroRestClient {
                 if (!child.attributes) {
                     return undefined
                 }
-
                 const id =
                     child.attributes.find(att => att.name === "id") ??
                     child.attributes.find(att => att.name === "dunesId")
-
                 const name =
                     child.attributes.find(att => att.name === "displayName") ??
                     child.attributes.find(att => att.name === "name")
-
                 const type =
                     child.attributes.find(att => att.name === "type") ??
                     child.attributes.find(att => att.name === "@type")
@@ -824,5 +823,9 @@ export class VroRestClient {
 
     async getPluginDetails(link: string) {
         return this.send("GET", `server-configuration/api/plugins/${link}`)
+    }
+
+    private loadCacheConfiguration(): void {
+        this.isCachingEnabled = this.settings?.vrdev?.vro?.inventory?.cache ?? false
     }
 }

--- a/packages/node/vrdt-common/src/rest/vro-model.ts
+++ b/packages/node/vrdt-common/src/rest/vro-model.ts
@@ -79,12 +79,25 @@ export interface InventoryElement extends Resource {
     href: string
 }
 
+export interface BaseAttribute {
+    name: string
+    value?: string
+}
+
+export interface TypeAttribute extends BaseAttribute {
+    type: string
+}
+
+export interface LinkItem {
+    attributes: TypeAttribute[]
+    rel: string
+    href: string
+    description?: BaseAttribute
+}
+
 export interface ContentLinksResponse {
-    link: {
-        attributes: { name: string; value: string; type: string }[]
-        rel: string
-        href: string
-    }[]
+    link: LinkItem[]
+    total?: number
 }
 
 export interface ContentChildrenResponse {

--- a/packages/node/vrdt-common/src/rest/vro-model.ts
+++ b/packages/node/vrdt-common/src/rest/vro-model.ts
@@ -47,16 +47,33 @@ export interface WorkflowLogsResponse {
     }[]
 }
 
-export interface ApiElement {
-    name: string
+export interface Resource {
     id: string
+    name: string
+}
+
+// For better readability a separate interface is created
+export interface Configuration extends Resource {
+    version: string
+}
+
+// For better readability a separate interface is created
+export interface Workflow extends Resource {
+    version: string
+}
+
+export interface Action {
+    id: string
+    fqn: string
+    version: string
+}
+
+export interface ApiElement extends Resource {
     type: ApiCategoryType | ApiElementType
     rel: string
 }
 
-export interface InventoryElement {
-    name: string
-    id: string
+export interface InventoryElement extends Resource {
     type: string
     rel: string
     href: string

--- a/packages/node/vrdt-common/src/types/settings.ts
+++ b/packages/node/vrdt-common/src/types/settings.ts
@@ -32,6 +32,15 @@ export interface TasksInfo {
     disable: boolean
     exclude: string[]
 }
+
+export interface VroInfo {
+    inventory: InventoryInfo
+}
+
+export interface InventoryInfo {
+    cache: boolean
+}
+
 export interface BuildTools {
     defaultVersion: string
 }
@@ -57,4 +66,5 @@ export interface VrealizeSettings {
     buildTools: BuildTools
     views: Views
     vra: VraInfo
+    vro: VroInfo
 }

--- a/packages/node/vro-language-server/src/constants.ts
+++ b/packages/node/vro-language-server/src/constants.ts
@@ -40,7 +40,9 @@ message Action {
 }`
 
 export const Timeout = {
-    ONE_SECOND: 1000
+    ONE_SECOND: 1000,
+    THREE_SECONDS: 3000,
+    FIVE_SECONDS: 5000
 }
 
 export enum CompletionPrefixKind {

--- a/packages/node/vro-language-server/src/constants.ts
+++ b/packages/node/vro-language-server/src/constants.ts
@@ -42,3 +42,12 @@ message Action {
 export const Timeout = {
     ONE_SECOND: 1000
 }
+
+export enum CompletionPrefixKind {
+    UNKNOWN = "Unknown",
+    CLASS_IMPORT = "Class Import",
+    CLASS_REFERENCE = "Class Reference",
+    STATIC_MEMBER_REFERENCE = "Static Member Reference",
+    NEW_INSTANCE = "New Instance",
+    MODULE_IMPORT = "Module Import"
+}

--- a/packages/node/vro-language-server/src/server/core/HintLookup.ts
+++ b/packages/node/vro-language-server/src/server/core/HintLookup.ts
@@ -211,7 +211,7 @@ export class HintLookup implements Disposable {
 
         if (!workspaceFolder) {
             // plugins aren't located in workspace folder
-            const coreApiFile = this.environment.resolveHintFile("core-api.pb")
+            const coreApiFile = this.environment.resolveHintFile("core-api.pb", undefined)
             const pluginFiles = this.environment.resolvePluginHintFiles()
 
             if (coreApiFile) {

--- a/packages/node/vro-language-server/src/server/core/HintLookup.ts
+++ b/packages/node/vro-language-server/src/server/core/HintLookup.ts
@@ -59,7 +59,7 @@ export class HintLookup implements Disposable {
 
     dispose(): void {
         this.logger.debug("Disposing HintLookup")
-        this.subscriptions.forEach(s => s?.dispose())
+        this.subscriptions.forEach(s => s && s.dispose())
     }
 
     getGlobalActionsPack() {
@@ -167,10 +167,6 @@ export class HintLookup implements Disposable {
         this.load()
     }
 
-    refreshForWorkspace(workspaceFolder: WorkspaceFolder): void {
-        this.load(workspaceFolder)
-    }
-
     private onDidChangeConfiguration(): void {
         this.logger.debug("HintLookup.onDidChangeConfiguration()")
         this.load()
@@ -181,6 +177,10 @@ export class HintLookup implements Disposable {
         for (const folder of event.added) {
             this.load(WorkspaceFolder.fromProtocol(folder))
         }
+    }
+
+    refreshForWorkspace(workspaceFolder: WorkspaceFolder): void {
+        this.load(workspaceFolder)
     }
 
     //
@@ -203,6 +203,7 @@ export class HintLookup implements Disposable {
                 )
             }
         }
+
         const configsFile = this.environment.resolveHintFile("configs.pb", workspaceFolder)
         if (configsFile) {
             this.loadProtoInScope([configsFile], workspaceFolder, this.configs, vmw.pscoe.hints.ConfigurationsPack)
@@ -210,8 +211,9 @@ export class HintLookup implements Disposable {
 
         if (!workspaceFolder) {
             // plugins aren't located in workspace folder
-            const coreApiFile = this.environment.resolveHintFile("core-api.pb", undefined)
+            const coreApiFile = this.environment.resolveHintFile("core-api.pb")
             const pluginFiles = this.environment.resolvePluginHintFiles()
+
             if (coreApiFile) {
                 pluginFiles.push(coreApiFile)
             }
@@ -237,6 +239,7 @@ export class HintLookup implements Disposable {
                 result.push(hintPack)
             }
         })
+
         if (!scope) {
             target.global = result
         } else {

--- a/packages/node/vro-language-server/src/server/request/collection/ServerCollection.ts
+++ b/packages/node/vro-language-server/src/server/request/collection/ServerCollection.ts
@@ -47,7 +47,7 @@ export class ServerCollection {
 
         connectionLocator.connection.onRequest(remote.server.triggerVroCollection, this.triggerCollection.bind(this))
 
-        this.restClient = new VroRestClient(settings, environment)
+        this.restClient = new VroRestClient(settings)
     }
 
     giveCollectionStatus(): CollectionStatus {

--- a/packages/node/vro-language-server/src/server/request/collection/ServerCollection.ts
+++ b/packages/node/vro-language-server/src/server/request/collection/ServerCollection.ts
@@ -162,7 +162,7 @@ export class ServerCollection {
             this.logger.error("No vRO objects found")
         } else {
             for (const plugin of plugins) {
-                const link = plugin.detailsLink.match(regex)
+                const link = RegExp(regex).exec(plugin.detailsLink)
                 if (!link) {
                     throw new Error(`No plugin details found`)
                 }

--- a/packages/node/vro-language-server/src/server/request/collection/ServerCollection.ts
+++ b/packages/node/vro-language-server/src/server/request/collection/ServerCollection.ts
@@ -4,12 +4,13 @@
  */
 
 import { CancellationToken } from "vscode-languageserver"
-import { AutoWire, HintAction, HintModule, HintPlugin, Logger, VroRestClient } from "@vmware/vrdt-common"
+import { AutoWire, HintAction, HintModule, HintPlugin, Logger, sleep, VroRestClient } from "@vmware/vrdt-common"
 
 import { remote } from "../../../public"
 import { ConnectionLocator, Environment, HintLookup, Settings } from "../../core"
 import { WorkspaceCollection } from "./WorkspaceCollection"
 import { vmw } from "../../../proto"
+import { Timeout } from "../../../constants"
 
 @AutoWire
 export class CollectionStatus {
@@ -97,6 +98,7 @@ export class ServerCollection {
 
     async getModulesAndActions() {
         this.logger.info("Collecting Modules and Actions...")
+        // fetch the root script module categories
         const modules: HintModule[] = (await this.restClient.getRootCategories("ScriptModuleCategory")).map(module => {
             return {
                 id: module.id,
@@ -104,24 +106,18 @@ export class ServerCollection {
                 actions: []
             }
         })
-        await Promise.all(
-            modules.map(
-                async module =>
-                    (module.actions = await this.restClient.getChildrenOfCategoryWithDetails(module.id).then(actions =>
-                        actions.map(action => {
-                            return {
-                                id: action.id,
-                                name: action.name,
-                                version: action.version,
-                                description: action.description,
-                                returnType: action.returnType,
-                                parameters: action.parameters
-                            } as HintAction
-                        })
-                    ))
-            )
-        )
+        // add delay between the 2 REST calls in order not to overload the vRO vco service cache
+        // see also: https://kb.vmware.com/s/article/95783?lang=en_US
+        await this.setDelay(Timeout.THREE_SECONDS)
+
+        // Enrichment of category actions execution has to be executed in serial order for not to overload the vRO
+        // see also: https://kb.vmware.com/s/article/95783?lang=en_US
+        for (const module of modules) {
+            await this.enrichHintModuleWithActions(module)
+        }
+
         this.logger.info("Modules and Actions collected from vRO")
+
         return modules
     }
 
@@ -166,10 +162,8 @@ export class ServerCollection {
                 if (!link) {
                     throw new Error(`No plugin details found`)
                 }
-
                 const parsedLink = link[0].substring(9).toString() // always retrieve and parse the first occurrence
                 const pluginDetails = await this.restClient.getPluginDetails(parsedLink)
-
                 for (const pluginObject of pluginDetails["objects"]) {
                     const object: vmw.pscoe.hints.IClass = {
                         name: pluginObject["name"]
@@ -195,5 +189,16 @@ export class ServerCollection {
         this.currentStatus.message = "An error occurred"
         this.currentStatus.error = message
         this.currentStatus.finished = true
+    }
+
+    private async setDelay(delayMs: number) {
+        await sleep(delayMs)
+    }
+
+    private async enrichHintModuleWithActions(module: HintModule): Promise<HintModule> {
+        const actions: HintAction[] = await this.restClient.getChildrenOfCategoryWithDetails(module.id)
+        module.actions = actions
+
+        return module
     }
 }

--- a/packages/node/vro-language-server/src/server/request/collection/WorkspaceCollection.ts
+++ b/packages/node/vro-language-server/src/server/request/collection/WorkspaceCollection.ts
@@ -68,6 +68,7 @@ export class WorkspaceCollection {
 
     async triggerCollectionAndRefresh(workspaceFolder: WorkspaceFolder): Promise<void> {
         await this.triggerCollection(workspaceFolder)
+        // workspace collection
         this.hints.refreshForWorkspace(workspaceFolder)
     }
 
@@ -84,7 +85,6 @@ export class WorkspaceCollection {
 
         const fullPath = path.join(workspaceFolder.uri.fsPath, modules.join(","))
         const modulesPath = path.join(fullPath, "src/main/resources")
-
         try {
             const payload = this.collectLocalData(modulesPath)
             this.generateActionsPbFiles(payload, outputDir, workspaceFolder)

--- a/wiki/Using-the-VS-Code-Extension.md
+++ b/wiki/Using-the-VS-Code-Extension.md
@@ -75,6 +75,10 @@ A vRO explorer view is available in the activity bar that allows browsing the wh
 
 ![vRO Explorer](./images/explorer.png)
 
+#### Inventory Caching
+
+There is a support for vRO inventory items caching in order not to overload vRO on heavily loaded environments. If the vrdev:vro:inventory:cache setting is enabled in the plugin settings, the vRO inventory items will be fetched once from the vRO server during visual studion code session. When there are changes in vRO inventory made during visual studio code session they will not be fetched. In order to maintain fresh load of data either disable the cache setting or reload the visual studio code.
+
 ### Push and Pull content
 
 The VS Code build tasks palette (<kbd>Cmd+Shift+B</kbd> / <kbd>Ctrl+Shift+B</kbd>) contains commands for pushing content to a live vRO/vRA instance and for pulling workflows, configurations, resources and vRA content back to your local machine – in a form suitable for committing into source control.


### PR DESCRIPTION
### Description

In order not to overload the vRO with REST requests to the inventory items REST endpoint in the vRO (on heavily loaded environment) a vRO inventory caching feature has been implemented that loads the inventory items lazy and caches during the  visual studio session runtime. The vRO data collection is executed in serial order (in order not to overload the vRO with a lot of parallel REST requests).

### Checklist

- [x] Lint and unit tests pass locally with my changes
- [x] I have tested against live vRO/vRA, if applicable
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Run the plugin against a real vRO environment, the action hinting should be fetched once thus fetching data only once, further REST request will be made until the refresh button is clicked or the IDE is reloaded. The vRO's vco micro service should not get overloaded with REST requests and no request are getting dropped.

### Release Notes

- Auto caching of vRO inventory items during initial IDE load (if the caching setting is enabled).
- The caching behavior may be disabled via the **_vrdev.vro.inventory.cache_** plugin setting. By default the setting is set to **_true_**
- vRO data collection REST requests are done serially for each of the category items.

### Related Issues
https://github.com/vmware/vrealize-developer-tools/issues/137
