### PR TITLE
fixed hinting for folder name with dash in it

### DIFF
--- a/packages/node/vro-language-server/src/server/feature/CompletionProvider.ts
+++ b/packages/node/vro-language-server/src/server/feature/CompletionProvider.ts
@@ -47,7 +47,7 @@ class CompletionPrefixPattern {
 const prefixPatterns = [
     new CompletionPrefixPattern(
         CompletionPrefixKind.MODULE_IMPORT,
-        /System\.getModule\s*\(["']((?:[a-zA-Z_$][\w$]*\.)*)([a-zA-Z_$]?[\w$]*)$/, // https://regex101.com/r/bsVfwk/1
+        /System\.getModule\s*\(["']((?:[a-zA-Z_$][-\w$]*\.)*)([a-zA-Z_$]?[\w$]*)$/, // https://regex101.com/r/WKCK3Y/1
         /Class\.load\s*\(["']((?:[a-zA-Z_$][\w$]*\.)*)([a-zA-Z_$]?[\w$]*)$/ // https://regex101.com/r/90B9Db/1
     ),
 


### PR DESCRIPTION
### Description

Fix for the hinting functionality when in the folder name there is a dash sign ("-").

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

### Testing

### Release Notes

<!--
-->

### Screenshot
![436855831_3563977883914947_4932449964221266178_n](https://github.com/vmware/vrealize-developer-tools/assets/167773478/02046a38-2fe2-4fac-8944-b1df7119d6a3)

### Related issues and PRs

