### PR TITLE
[RunAction, logging] (#159) Restored System and Server logs in VRDT OUTPUT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
           name: codecov
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: runner.os == 'ubuntu-latest'
         with:
           name: vrealize-developer-tools-${{steps.version_step.outputs.version_build}}.vsix

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -70,7 +70,7 @@ jobs:
           MINISIGN_PASSWORD: ${{ secrets.RELEASE_MINISIGN_PASS }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: vrealize-developer-tools-${{steps.version_step.outputs.version}}
           path: |

--- a/extension/src/client/command/RunAction.ts
+++ b/extension/src/client/command/RunAction.ts
@@ -415,7 +415,8 @@ abstract class FetchSysLogsStrategy extends FetchLogsStrategy {
         const logs = await this.getLogMessages()
         logs.forEach(logMessage => {
             const timestamp = moment(logMessage.timestamp).format("YYYY-MM-DD HH:mm:ss.SSS ZZ")
-            const msg = `[${timestamp}] [${logMessage.severity}] ${logMessage.description}`
+            const origin = !logMessage.origin ? "" : `[${logMessage.origin}] `
+            const msg = `[${timestamp}] ${origin}[${logMessage.severity}] ${logMessage.description}`
             if (!this.printedMessages.has(msg)) {
                 this.log(msg)
                 this.printedMessages.add(msg)

--- a/extension/src/client/command/RunAction.ts
+++ b/extension/src/client/command/RunAction.ts
@@ -280,7 +280,6 @@ class ActionRunner {
         }
 
         this.logger.info(`Running workflow ${RUN_SCRIPT_WORKFLOW_ID} (vRO ${this.vroVersion})`)
-        const supportsSysLog = semver.gt(this.vroVersion, "7.3.1")
         const params = [
             {
                 name: "script",
@@ -293,7 +292,7 @@ class ActionRunner {
                 name: "printInOutput",
                 type: "boolean",
                 value: {
-                    boolean: { value: !supportsSysLog }
+                    boolean: { value: true }
                 }
             }
         ]
@@ -416,6 +415,9 @@ abstract class FetchSysLogsStrategy extends FetchLogsStrategy {
     protected abstract getLogMessages(): Promise<LogMessage[]>
 
     async printMessages(): Promise<void> {
+        if (Logger.level === "off") {
+            return
+        }
         const timestamp = Date.now() - 10000 // 10sec earlier
         const logs = await this.getLogMessages()
         logs.forEach(logMessage => {
@@ -455,7 +457,7 @@ class FetchLogsPre76 extends FetchSysLogsStrategy {
         return this.restClient.getWorkflowLogsPre76(
             RUN_SCRIPT_WORKFLOW_ID,
             this.executionToken,
-            "debug",
+            Logger.level,
             this.lastTimestamp
         )
     }
@@ -475,7 +477,7 @@ class FetchLogsPost76 extends FetchSysLogsStrategy {
         return this.restClient.getWorkflowLogsPost76(
             RUN_SCRIPT_WORKFLOW_ID,
             this.executionToken,
-            "debug",
+            Logger.level,
             this.lastTimestamp
         )
     }

--- a/extension/src/client/command/RunAction.ts
+++ b/extension/src/client/command/RunAction.ts
@@ -287,13 +287,6 @@ class ActionRunner {
                 value: {
                     string: { value: fileContent }
                 }
-            },
-            {
-                name: "printInOutput",
-                type: "boolean",
-                value: {
-                    boolean: { value: true }
-                }
             }
         ]
 

--- a/packages/node/vrdt-common/src/logger.ts
+++ b/packages/node/vrdt-common/src/logger.ts
@@ -37,6 +37,13 @@ export default class Logger {
         }
     }
 
+    /**
+     * Configured log level.
+     */
+    static get level(): LogLevel {
+        return Logger.logLevel
+    }
+
     debug(message: string, data?: any): void {
         if (this.channel && Logger.logLevel === "debug") {
             this.channel.debug(this.format("DEBUG", message, data))

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -321,8 +321,7 @@ export class VroRestClient {
             "GET",
             `workflows/${workflowId}/executions/${executionId}/syslogs` +
                 `?conditions=severity=${severity}` +
-                `&conditions=timestamp${encodeURIComponent(">")}${timestamp}` +
-                "&conditions=type=system"
+                `&conditions=timestamp${encodeURIComponent(">")}${timestamp}` // + "&conditions=type=system"
         )
 
         const messages: LogMessage[] = []

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -334,7 +334,8 @@ export class VroRestClient {
             messages.push({
                 timestamp: e["time-stamp"],
                 severity: e.severity,
-                description
+                description,
+                origin: e.origin
             })
         }
 

--- a/packages/node/vrdt-common/src/rest/VroRestClient.ts
+++ b/packages/node/vrdt-common/src/rest/VroRestClient.ts
@@ -321,7 +321,7 @@ export class VroRestClient {
             "GET",
             `workflows/${workflowId}/executions/${executionId}/syslogs` +
                 `?conditions=severity=${severity}` +
-                `&conditions=timestamp${encodeURIComponent(">")}${timestamp}` // + "&conditions=type=system"
+                `&conditions=timestamp${encodeURIComponent(">")}${timestamp}`
         )
 
         const messages: LogMessage[] = []

--- a/packages/node/vrdt-common/src/rest/vro-model.ts
+++ b/packages/node/vrdt-common/src/rest/vro-model.ts
@@ -15,6 +15,7 @@ export interface LogMessage {
     timestamp: string
     severity: string
     description: string
+    origin?: string
 }
 
 export interface Version {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute! -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
Restored System and Server logs in VRDT OUTPUT.
Fetching logs via API call depending on the configured Vrdev Log level in the plugin settings.
Requires changes to the Run Script XML WF in BTVA > packages > exec (see related PR).
<!--
Please include a summary of the changes and which issue will be addressed.
Please also include relevant motivation and context.
-->

### Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] I have tested against live vRO/vRA, if applicable
- [x] My changes have been rebased and squashed to the minimal number of relevant commits
- [x] My changes have a descriptive commit message with a short title, including a `Fixed #XXX -` or `Closed #XXX -` prefix to auto-close the issue

### Testing

Tested by running a JS action (without return type and parameters) from a test project in:
- VScode 1.94.1
- BTVA 2.43.1-SNAPSHOT

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in vRealize Developer Tools' release notes.

If this change is not user-facing or notable enough to be included in release notes
you should delete this section (or leave it empty).

Examples:

- New setting to *exclude* certain projects from the list of build tasks (`Cmd+Shift+B`) by using glob patterns.
- Support for Multi-root Workspaces that allows opening more than one vRO project into single vscode window.
- Dynamically create build tasks (`Cmd+Shift+B`) based on project's type and modules.

-->

### Screenshot

<!-- Include an image of the most relevant user-facing change, if any. -->
![vrdtOutputLogsOff](https://github.com/user-attachments/assets/17f6659f-86da-408b-9201-4ce86940b5a8)
![vrdtOutputLogsDebug](https://github.com/user-attachments/assets/c9b0ffdd-24a6-4329-a2ec-f00fc5a3415d)
![vrdtOutputLogsInfo](https://github.com/user-attachments/assets/285af4b9-6baf-47ac-9661-de797569b75c)

### Related issues and PRs

VRDT issue: https://github.com/vmware/vrealize-developer-tools/issues/159
Related BTVA PR: https://github.com/vmware/build-tools-for-vmware-aria/pull/450
