### PR TITLE
Potential fix for code scanning alert no. 26: Unsafe shell command constructed from library input

### DIFF
--- a/packages/node/vrdt-common/src/maven/MavenCliProxy.ts
+++ b/packages/node/vrdt-common/src/maven/MavenCliProxy.ts
@@ -71,23 +71,26 @@ export class MavenCliProxy {
             archetypeGroup = "vra-ng"
         }
 
-        let command =
-            `mvn archetype:generate -DinteractiveMode=false ` +
-            `-DarchetypeGroupId=com.vmware.pscoe.${archetypeGroup}.archetypes ` +
-            `-DarchetypeArtifactId=${archetypeId} ` +
-            `-DarchetypeVersion=${this.environment.buildToolsVersion} ` +
-            `-DgroupId=${groupId} ` +
+        let mavenCmd = 'mvn';
+        let args = [
+            'archetype:generate',
+            '-DinteractiveMode=false',
+            `-DarchetypeGroupId=com.vmware.pscoe.${archetypeGroup}.archetypes`,
+            `-DarchetypeArtifactId=${archetypeId}`,
+            `-DarchetypeVersion=${this.environment.buildToolsVersion}`,
+            `-DgroupId=${groupId}`,
             `-DartifactId=${artifactId}`
+        ];
 
         if (requiresWorkflows) {
             if (!workflowsPath) {
                 return Promise.reject(`Project type ${projectType} requires a workflows directory`)
             }
 
-            command += ` -DworkflowsPath="${workflowsPath}"`
+            args.push(`-DworkflowsPath=${workflowsPath}`);
         }
 
-        return proc.exec(command, { cwd: destinationDir }, this.logger)
+        return proc.execFile(mavenCmd, args, { cwd: destinationDir }, this.logger)
     }
 
     copyDependency(


### PR DESCRIPTION
Potential fix for [https://github.com/vmware/vrealize-developer-tools/security/code-scanning/26](https://github.com/vmware/vrealize-developer-tools/security/code-scanning/26)

To fix this issue, we need to ensure that untrusted input (`workflowsPath`, as well as any other interpolated data) does not cause unexpected behavior or command injection when constructing and executing shell commands. The general approach is to avoid concatenating unsanitized inputs into shell command strings. There are two options:

1. If possible, invoke the command using an array of arguments (with `child_process.execFile` or equivalent), so that arguments are properly escaped and not interpreted by the shell.
2. If the command **must** be constructed such that the shell is required (for example, if you are using pipes, redirection, etc.), escape any potentially unsafe input using a library like `shell-quote`.

In this context, since the command seems not to require shell-specific features (no pipes, redirection, etc.), the best fix is to construct an argument array and use `proc.execFile` instead of `proc.exec`, passing input as arguments. This entails:

- Refactoring the construction of the Maven command so that it is split into a command name and an arguments array.
- Updating the call to `proc.exec` to use `proc.execFile` (or equivalent), or refactoring `proc.exec` itself if it wraps both kinds of execution.
- Ensuring all values interpolated into command-line arguments (like `workflowsPath`, `groupId`, `artifactId`, etc.) are passed as array elements rather than interpolated into a string.

Necessary changes are limited to the `createProject` method in `MavenCliProxy.ts`:
- Construct the command and its arguments as separate strings and arrays.
- Use `proc.execFile` (presuming it exists and functions like Node’s `child_process.execFile`).

If the `proc` module does not already support execFile, you may need to implement that or, minimally, adjust `proc.exec` to allow array arguments (but only within the shown code).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
